### PR TITLE
[Feat] - 결과 화면에 ChatGpt API 연결

### DIFF
--- a/PostKit/PostKit.xcodeproj/project.pbxproj
+++ b/PostKit/PostKit.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		7EF314CA2AD81D6A008E7338 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EF314C92AD81D6A008E7338 /* Constants.swift */; };
 		7EF314CC2AD81DC3008E7338 /* ChatGptService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EF314CB2AD81DC3008E7338 /* ChatGptService.swift */; };
 		7EF314CE2AD81DE3008E7338 /* ChatGptModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EF314CD2AD81DE3008E7338 /* ChatGptModel.swift */; };
+		7EF314D22AD96A69008E7338 /* ChatGptViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EF314D12AD96A68008E7338 /* ChatGptViewModel.swift */; };
 		A188C5752AD79DDF007473D3 /* DailyModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A188C5742AD79DDF007473D3 /* DailyModel.swift */; };
 		A188C5772AD79E0E007473D3 /* MenuModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A188C5762AD79E0E007473D3 /* MenuModel.swift */; };
 		A188C5792AD79E89007473D3 /* StoreModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A188C5782AD79E89007473D3 /* StoreModel.swift */; };
@@ -95,6 +96,7 @@
 		7EF314C92AD81D6A008E7338 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		7EF314CB2AD81DC3008E7338 /* ChatGptService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatGptService.swift; sourceTree = "<group>"; };
 		7EF314CD2AD81DE3008E7338 /* ChatGptModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatGptModel.swift; sourceTree = "<group>"; };
+		7EF314D12AD96A68008E7338 /* ChatGptViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatGptViewModel.swift; sourceTree = "<group>"; };
 		A188C5742AD79DDF007473D3 /* DailyModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyModel.swift; sourceTree = "<group>"; };
 		A188C5762AD79E0E007473D3 /* MenuModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuModel.swift; sourceTree = "<group>"; };
 		A188C5782AD79E89007473D3 /* StoreModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreModel.swift; sourceTree = "<group>"; };
@@ -209,6 +211,7 @@
 				A188C5842AD7BA89007473D3 /* StoreDataManager.swift */,
 				B98632692AD7D13400DE9FF5 /* KeyboardObserver.swift */,
 				7EF314CB2AD81DC3008E7338 /* ChatGptService.swift */,
+				7EF314D12AD96A68008E7338 /* ChatGptViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -450,6 +453,7 @@
 				A188C5832AD7BA5F007473D3 /* MenuDataManager.swift in Sources */,
 				7EF314CC2AD81DC3008E7338 /* ChatGptService.swift in Sources */,
 				13C296102AD8F16700A2DE7F /* OnboardingRouter.swift in Sources */,
+				7EF314D22AD96A69008E7338 /* ChatGptViewModel.swift in Sources */,
 				13C295DD2AD6B48400A2DE7F /* DesginSystem.swift in Sources */,
 				13C295C82AD620EC00A2DE7F /* MainView.swift in Sources */,
 				13C2960C2AD8F15300A2DE7F /* OnboardingFinal.swift in Sources */,

--- a/PostKit/PostKit/View/MenuView.swift
+++ b/PostKit/PostKit/View/MenuView.swift
@@ -21,7 +21,7 @@ struct MenuView: View {
 
 
     // TODO: 온보딩 페이지가 완성되면 해당 부분 수정할 예정입니다~
-    @State var messages: [Message] = [Message(id: UUID(), role: .system, content: "너는 루시드 드림 카페의 사장이고 친근한 말투를 가지고 있어. 글은 존댓말로 작성해줘.")]
+    @State var messages: [Message] = [Message(id: UUID(), role: .system, content: "너는 루시드 드림 카페를 운영하고 있으며 친근한 말투를 가지고 있어. 글은 존댓말로 작성해줘. 글은 700자 정도로 작성해줘.")]
     @State var currentInput: String = ""
     
     private let chatGptService = ChatGptService()

--- a/PostKit/PostKit/View/MenuView.swift
+++ b/PostKit/PostKit/View/MenuView.swift
@@ -18,7 +18,7 @@ struct MenuView: View {
     @State var drinkSelected: [String] = []
     @State var dessertSelected: [String] = []
     
-
+    @ObservedObject var viewModel = ChatGptViewModel.shared
 
     // TODO: 온보딩 페이지가 완성되면 해당 부분 수정할 예정입니다~
     @State var messages: [Message] = [Message(id: UUID(), role: .system, content: "너는 루시드 드림 카페를 운영하고 있으며 친근한 말투를 가지고 있어. 글은 존댓말로 작성해줘. 글은 700자 정도로 작성해줘.")]
@@ -90,6 +90,7 @@ struct MenuView: View {
         .padding(.horizontal,paddingHorizontal)
     }
     
+    // MARK: - Chat Gpt API에 응답 요청
     func sendMessage(){
         Task{
             var pointText = ""
@@ -117,11 +118,12 @@ struct MenuView: View {
             
             self.currentInput = "메뉴의 이름은 \(self.menuName)인 메뉴에 대해서 인스타그램 피드를 작성해줘. \(pointText)"
             let newMessage = Message(id: UUID(), role: .user, content: self.currentInput)
-            
             self.messages.append(newMessage)
+            viewModel.prompt = self.currentInput
             self.currentInput = ""
-            
             let response = await chatGptService.sendMessage(messages: self.messages)
+            viewModel.promptAnswer = response?.choices.first?.message.content == nil ? "" : response!.choices.first!.message.content
+            print(response?.choices.first?.message.content as Any)
             print(response as Any)
         }
     }

--- a/PostKit/PostKit/View/ResultView.swift
+++ b/PostKit/PostKit/View/ResultView.swift
@@ -68,12 +68,24 @@ struct ResultView: View {
                 pathManager.path.removeAll()
             } rightAction: {
                 // TODO: 카피 재생성 기능
+                regenerateAnswer()
             }
             .padding(.vertical, 12)
             
         }
         .padding(.horizontal, paddingHorizontal)
         .toast(isShowing: $isShowingToast)
+    }
+    
+    // MARK: - Chat GPT API에 재생성 요청
+    func regenerateAnswer() {
+        Task{
+            let newMessage = Message(id: UUID(), role: .user, content: viewModel.prompt)
+            self.messages.append(newMessage)
+            let response = await chatGptService.sendMessage(messages: self.messages)
+            print(response as Any)
+            viewModel.promptAnswer = response?.choices.first?.message.content == nil ? "" : response!.choices.first!.message.content
+        }
     }
     
     // MARK: - 카피 복사

--- a/PostKit/PostKit/View/ResultView.swift
+++ b/PostKit/PostKit/View/ResultView.swift
@@ -14,6 +14,9 @@ struct ResultView: View {
     @State private var copyResult = "생성된 텍스트가 들어가요."
     @State private var isShowingToast = false
     private let pasteBoard = UIPasteboard.general
+    @State var messages: [Message] = [Message(id: UUID(), role: .system, content: "너는 루시드 드림 카페를 운영하고 있으며 친근한 말투를 가지고 있어. 글은 존댓말로 작성해줘. 글은 700자 정도로 작성해줘.")]
+    @ObservedObject var viewModel = ChatGptViewModel.shared
+    private let chatGptService = ChatGptService()
     
     var body: some View {
         VStack {
@@ -31,7 +34,7 @@ struct ResultView: View {
                 // MARK: - 생성된 카피 출력 + 복사하기 버튼
                 VStack(alignment: .trailing, spacing: 20) {
                     VStack(alignment: .leading) {
-                        Text(copyResult)
+                        Text(viewModel.promptAnswer)
                             .multilineTextAlignment(.leading)
                             .font(.body1Bold())
                             .foregroundStyle(Color.gray5)

--- a/PostKit/PostKit/View/ResultView.swift
+++ b/PostKit/PostKit/View/ResultView.swift
@@ -90,7 +90,7 @@ struct ResultView: View {
     
     // MARK: - 카피 복사
     func copyToClipboard() {
-        pasteBoard.string = copyResult
+        pasteBoard.string = viewModel.promptAnswer
         isShowingToast = true
     }
 }

--- a/PostKit/PostKit/ViewModel/ChatGptViewModel.swift
+++ b/PostKit/PostKit/ViewModel/ChatGptViewModel.swift
@@ -1,0 +1,21 @@
+//
+//  ChatGptViewModel.swift
+//  PostKit
+//
+//  Created by doeun kim on 10/13/23.
+//
+
+import Foundation
+
+// MARK: - ChatGpt prompt와 prompt답변 관리
+final class ChatGptViewModel: ObservableObject {
+    static let shared = ChatGptViewModel()
+    
+    @Published var prompt : String
+    @Published var promptAnswer :String
+    
+    init(prompt: String = "", promptAnswer: String = "생성된 텍스트가 들어가요.") {
+        self.prompt = prompt
+        self.promptAnswer = promptAnswer
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
close #28 

## Task TODOLIST
- [x] 결과 화면에 Chatgpt API 연결

## ✨ 개발 내용
<!-- 개발에 대한 내용을 적어주세요 -->
- 결과 화면에 chatgpt 응답 내용 표시
- 결과 화면의 복사 기능 수정
-  chatgpt 응답 내용 및 prompt 관리 viewModel 생성
``` swift
final class ChatGptViewModel: ObservableObject {
    static let shared = ChatGptViewModel()

    @Published var prompt : String
    @Published var promptAnswer :String
    init(prompt: String = "", promptAnswer: String = "생성된 텍스트가 들어가요.") {
        self.prompt = prompt
        self.promptAnswer = promptAnswer
    }
}
```
- 결과 화면의 재생성 기능 구현

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
<img width="323" alt="image" src="https://github.com/ADA-RLD/PostKit/assets/61380136/8ad3b8ba-9bc6-4d4e-b202-022d1ce46d61">
<img width="317" alt="image" src="https://github.com/ADA-RLD/PostKit/assets/61380136/413532ef-e186-439b-8eea-bb85c66670df">