### PR TITLE
Rash refactor/#68

### DIFF
--- a/PostKit/PostKit.xcodeproj/project.pbxproj
+++ b/PostKit/PostKit.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		139B2C7E2ADFF8690036BD18 /* CustomVstack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 139B2C7D2ADFF8690036BD18 /* CustomVstack.swift */; };
+		139B2C7E2ADFF8690036BD18 /* ContentArea.swift in Sources */ = {isa = PBXBuildFile; fileRef = 139B2C7D2ADFF8690036BD18 /* ContentArea.swift */; };
 		13C295B12AD55F2100A2DE7F /* PostKitApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13C295B02AD55F2100A2DE7F /* PostKitApp.swift */; };
 		13C295B52AD55F2200A2DE7F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13C295B42AD55F2200A2DE7F /* Assets.xcassets */; };
 		13C295B82AD55F2200A2DE7F /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13C295B72AD55F2200A2DE7F /* Preview Assets.xcassets */; };
@@ -67,7 +67,7 @@
 
 /* Begin PBXFileReference section */
 		0A14ED0B2AD96D9A00357A79 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
-		139B2C7D2ADFF8690036BD18 /* CustomVstack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomVstack.swift; sourceTree = "<group>"; };
+		139B2C7D2ADFF8690036BD18 /* ContentArea.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentArea.swift; sourceTree = "<group>"; };
 		13C295AD2AD55F2100A2DE7F /* PostKit.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PostKit.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13C295B02AD55F2100A2DE7F /* PostKitApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostKitApp.swift; sourceTree = "<group>"; };
 		13C295B42AD55F2200A2DE7F /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -237,7 +237,7 @@
 				B98632632AD7CFEE00DE9FF5 /* Keywords.swift */,
 				13C296172AD8F1F000A2DE7F /* CustomHeader.swift */,
 				13C296192AD8F26300A2DE7F /* SelectTone.swift */,
-				139B2C7D2ADFF8690036BD18 /* CustomVstack.swift */,
+				139B2C7D2ADFF8690036BD18 /* ContentArea.swift */,
 			);
 			path = Component;
 			sourceTree = "<group>";
@@ -461,7 +461,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				139B2C7E2ADFF8690036BD18 /* CustomVstack.swift in Sources */,
+				139B2C7E2ADFF8690036BD18 /* ContentArea.swift in Sources */,
 				7EF314CE2AD81DE3008E7338 /* ChatGptModel.swift in Sources */,
 				13C2961A2AD8F26300A2DE7F /* SelectTone.swift in Sources */,
 				13C296242AD988FC00A2DE7F /* AppStorageManager.swift in Sources */,

--- a/PostKit/PostKit.xcodeproj/project.pbxproj
+++ b/PostKit/PostKit.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		139B2C7E2ADFF8690036BD18 /* CustomVstack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 139B2C7D2ADFF8690036BD18 /* CustomVstack.swift */; };
 		13C295B12AD55F2100A2DE7F /* PostKitApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13C295B02AD55F2100A2DE7F /* PostKitApp.swift */; };
 		13C295B52AD55F2200A2DE7F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13C295B42AD55F2200A2DE7F /* Assets.xcassets */; };
 		13C295B82AD55F2200A2DE7F /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13C295B72AD55F2200A2DE7F /* Preview Assets.xcassets */; };
@@ -16,7 +17,7 @@
 		13C295D82AD68BEA00A2DE7F /* SettingStoreView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13C295D72AD68BEA00A2DE7F /* SettingStoreView.swift */; };
 		13C295DA2AD68BF600A2DE7F /* SettingToneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13C295D92AD68BF600A2DE7F /* SettingToneView.swift */; };
 		13C295DD2AD6B48400A2DE7F /* DesginSystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13C295DC2AD6B48400A2DE7F /* DesginSystem.swift */; };
-		13C295DF2AD6C01300A2DE7F /* CustomBtn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13C295DE2AD6C01300A2DE7F /* CustomBtn.swift */; };
+		13C295DF2AD6C01300A2DE7F /* CtaBtn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13C295DE2AD6C01300A2DE7F /* CtaBtn.swift */; };
 		13C295ED2AD7136E00A2DE7F /* Pretendard-Medium.otf in Resources */ = {isa = PBXBuildFile; fileRef = 13C295E42AD7136D00A2DE7F /* Pretendard-Medium.otf */; };
 		13C295EE2AD7136E00A2DE7F /* Pretendard-ExtraBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 13C295E52AD7136D00A2DE7F /* Pretendard-ExtraBold.otf */; };
 		13C295EF2AD7136E00A2DE7F /* Pretendard-SemiBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 13C295E62AD7136D00A2DE7F /* Pretendard-SemiBold.otf */; };
@@ -66,6 +67,7 @@
 
 /* Begin PBXFileReference section */
 		0A14ED0B2AD96D9A00357A79 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
+		139B2C7D2ADFF8690036BD18 /* CustomVstack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomVstack.swift; sourceTree = "<group>"; };
 		13C295AD2AD55F2100A2DE7F /* PostKit.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PostKit.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13C295B02AD55F2100A2DE7F /* PostKitApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostKitApp.swift; sourceTree = "<group>"; };
 		13C295B42AD55F2200A2DE7F /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -76,7 +78,7 @@
 		13C295D72AD68BEA00A2DE7F /* SettingStoreView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingStoreView.swift; sourceTree = "<group>"; };
 		13C295D92AD68BF600A2DE7F /* SettingToneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingToneView.swift; sourceTree = "<group>"; };
 		13C295DC2AD6B48400A2DE7F /* DesginSystem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesginSystem.swift; sourceTree = "<group>"; };
-		13C295DE2AD6C01300A2DE7F /* CustomBtn.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomBtn.swift; sourceTree = "<group>"; };
+		13C295DE2AD6C01300A2DE7F /* CtaBtn.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CtaBtn.swift; sourceTree = "<group>"; };
 		13C295E42AD7136D00A2DE7F /* Pretendard-Medium.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Medium.otf"; sourceTree = "<group>"; };
 		13C295E52AD7136D00A2DE7F /* Pretendard-ExtraBold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-ExtraBold.otf"; sourceTree = "<group>"; };
 		13C295E62AD7136D00A2DE7F /* Pretendard-SemiBold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-SemiBold.otf"; sourceTree = "<group>"; };
@@ -230,11 +232,12 @@
 		13C295CD2AD6211700A2DE7F /* Component */ = {
 			isa = PBXGroup;
 			children = (
-				13C295DE2AD6C01300A2DE7F /* CustomBtn.swift */,
+				13C295DE2AD6C01300A2DE7F /* CtaBtn.swift */,
 				B98632612AD7CFD500DE9FF5 /* CustomTextfield.swift */,
 				B98632632AD7CFEE00DE9FF5 /* Keywords.swift */,
 				13C296172AD8F1F000A2DE7F /* CustomHeader.swift */,
 				13C296192AD8F26300A2DE7F /* SelectTone.swift */,
+				139B2C7D2ADFF8690036BD18 /* CustomVstack.swift */,
 			);
 			path = Component;
 			sourceTree = "<group>";
@@ -458,6 +461,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				139B2C7E2ADFF8690036BD18 /* CustomVstack.swift in Sources */,
 				7EF314CE2AD81DE3008E7338 /* ChatGptModel.swift in Sources */,
 				13C2961A2AD8F26300A2DE7F /* SelectTone.swift in Sources */,
 				13C296242AD988FC00A2DE7F /* AppStorageManager.swift in Sources */,
@@ -472,7 +476,7 @@
 				A188C5772AD79E0E007473D3 /* MenuModel.swift in Sources */,
 				B98632642AD7CFEE00DE9FF5 /* Keywords.swift in Sources */,
 				B98632662AD7D01500DE9FF5 /* WrappingHStack.swift in Sources */,
-				13C295DF2AD6C01300A2DE7F /* CustomBtn.swift in Sources */,
+				13C295DF2AD6C01300A2DE7F /* CtaBtn.swift in Sources */,
 				B98632682AD7D03800DE9FF5 /* MenuView.swift in Sources */,
 				13C296142AD8F17D00A2DE7F /* OnboardingTone.swift in Sources */,
 				13C296162AD8F18900A2DE7F /* OnboardingView.swift in Sources */,

--- a/PostKit/PostKit/View/Caption/DailyView.swift
+++ b/PostKit/PostKit/View/Caption/DailyView.swift
@@ -116,7 +116,7 @@ struct DailyView: View {
                     }
                 }
                 .scrollIndicators(.hidden)
-                CustomBtn(btnDescription: "카피 생성", isActive: .constant(true), action: {
+                CtaBtn(btnDescription: "카피 생성", isActive: .constant(true), action: {
                     sendMessage()
                     pathManager.path.append(.CaptionResult)
                 })

--- a/PostKit/PostKit/View/Caption/MenuView.swift
+++ b/PostKit/PostKit/View/Caption/MenuView.swift
@@ -83,7 +83,7 @@ struct MenuView: View {
                     .foregroundStyle(Color.gray5)
                     .font(.body2Bold())
                 }
-                CustomBtn(btnDescription: "카피 생성", isActive: self.$isActive, action: {
+                CtaBtn(btnDescription: "카피 생성", isActive: self.$isActive, action: {
                     if isActive == true {
                         sendMessage()
                         pathManager.path.append(.CaptionResult)

--- a/PostKit/PostKit/View/Component/ContentArea.swift
+++ b/PostKit/PostKit/View/Component/ContentArea.swift
@@ -7,8 +7,8 @@
 
 import SwiftUI
 
-//MARK: Padding값을 미리 적용해서 CustomVstack을 적용
-struct CustomVstack<T: View>: View {
+//MARK: Padding값을 미리 적용해서 ContentArea라는 ViewBuilder를 만들어서 이제 따로 전체 패딩값을 주지 않아도 됩니다.
+struct ContentArea<T: View>: View {
     let content: T
     
     init(@ViewBuilder content: () -> T) {
@@ -25,17 +25,21 @@ struct CustomVstack<T: View>: View {
 }
 
 //CustomVstack을 활용한 뷰 예시
-import SwiftUI
 
 struct SampleView: View {
     var body: some View {
         VStack {
-            CustomVstack {
-                VStack() {
+            ContentArea {
+                VStack(spacing:40) {
                     Rectangle()
+                        .frame(height: 30)
+                    Rectangle()
+                        .frame(height: 30)
                     
                 }
+                .border(.blue)
             }
+            .border(.red)
             CtaBtn(btnDescription: "dd", isActive: .constant(true), action: {print("")})
         }
     }

--- a/PostKit/PostKit/View/Component/ContentArea.swift
+++ b/PostKit/PostKit/View/Component/ContentArea.swift
@@ -24,8 +24,8 @@ struct ContentArea<T: View>: View {
     }
 }
 
-//CustomVstack을 활용한 뷰 예시
-
+//MARK: CustomVstack을 활용한 뷰 예시
+/*
 struct SampleView: View {
     var body: some View {
         VStack {
@@ -48,3 +48,4 @@ struct SampleView: View {
 #Preview {
     SampleView()
 }
+*/

--- a/PostKit/PostKit/View/Component/CtaBtn.swift
+++ b/PostKit/PostKit/View/Component/CtaBtn.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 // TODO: 색상 에셋 추가되면 색 바꿔야 해요
-struct CustomBtn: View {
+struct CtaBtn: View {
     var btnDescription: String
     @Binding var isActive: Bool
     var action: () -> Void
@@ -29,6 +29,7 @@ struct CustomBtn: View {
                 
             })
         }
+        .padding(.horizontal,paddingHorizontal)
         .padding(.vertical,12)
 
     }
@@ -41,7 +42,7 @@ struct CustomDoubleeBtn: View {
     var leftAction: () -> Void
     var rightAction: () -> Void
     var body: some View {
-        HStack {
+        HStack(spacing: 8) {
             Button(action: {
                 leftAction()
             }, label: {
@@ -68,6 +69,9 @@ struct CustomDoubleeBtn: View {
         }
         .frame(maxWidth: .infinity)
         .frame(height: 56)
+        .padding(.horizontal,paddingHorizontal)
+        .padding(.vertical,12)
+      
     }
 }
 

--- a/PostKit/PostKit/View/Component/CtaBtn.swift
+++ b/PostKit/PostKit/View/Component/CtaBtn.swift
@@ -28,6 +28,7 @@ struct CtaBtn: View {
                     }
                 
             })
+            .disabled(!isActive)
         }
         .padding(.horizontal,paddingHorizontal)
         .padding(.vertical,12)

--- a/PostKit/PostKit/View/Component/CtaBtn.swift
+++ b/PostKit/PostKit/View/Component/CtaBtn.swift
@@ -13,7 +13,7 @@ struct CtaBtn: View {
     @Binding var isActive: Bool
     var action: () -> Void
     var body: some View {
-        VStack {
+        VStack(spacing: 0) {
             Button(action: {
                 action()
             }, label: {

--- a/PostKit/PostKit/View/Component/CustomHeader.swift
+++ b/PostKit/PostKit/View/Component/CustomHeader.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct CustomHeader: View {
     var action: () -> Void
-    var title: String
+    var title: String?
     var body: some View {
         HStack() {
             Button(action: {
@@ -21,7 +21,7 @@ struct CustomHeader: View {
                     .frame(width: 24, height: 24)
             })
             Spacer()
-            Text(title)
+            Text(title ?? "")
                 .font(.body1Bold())
             Spacer()
         }
@@ -45,10 +45,13 @@ struct OnboardingCustomHeader: View {
                     .frame(width: 24, height: 24)
             })
             Spacer()
-            .padding(.leading,16)
+           
             
             
         }
+        .padding(.trailing, 40.0)
+        .padding(.leading,16)
+        .frame(height: 60)
     }
 }
 

--- a/PostKit/PostKit/View/Component/CustomVstack.swift
+++ b/PostKit/PostKit/View/Component/CustomVstack.swift
@@ -1,0 +1,46 @@
+//
+//  CustomVstack.swift
+//  PostKit
+//
+//  Created by 김다빈 on 10/18/23.
+//
+
+import SwiftUI
+
+//MARK: Padding값을 미리 적용해서 CustomVstack을 적용
+struct CustomVstack<T: View>: View {
+    let content: T
+    
+    init(@ViewBuilder content: () -> T) {
+           self.content = content()
+       }
+    
+    var body: some View {
+            content
+                .padding(.horizontal,paddingHorizontal)
+                .padding(.top,paddingTop)
+                .padding(.bottom,paddingBottom)
+
+    }
+}
+
+//CustomVstack을 활용한 뷰 예시
+import SwiftUI
+
+struct SampleView: View {
+    var body: some View {
+        VStack {
+            CustomVstack {
+                VStack() {
+                    Rectangle()
+                    
+                }
+            }
+            CtaBtn(btnDescription: "dd", isActive: .constant(true), action: {print("")})
+        }
+    }
+}
+
+#Preview {
+    SampleView()
+}

--- a/PostKit/PostKit/View/Onboarding/OnboardingFinal.swift
+++ b/PostKit/PostKit/View/Onboarding/OnboardingFinal.swift
@@ -27,7 +27,7 @@ struct OnboardingFinal: View {
                     .foregroundStyle(Color.gray4)
                     .padding(.top,40)
                 Spacer()
-                CustomBtn(btnDescription:"확인", isActive: .constant(true), action: {isFirstLaunching.toggle()})
+                CtaBtn(btnDescription:"확인", isActive: .constant(true), action: {isFirstLaunching.toggle()})
             }
             .padding(.horizontal,paddingHorizontal)
         }

--- a/PostKit/PostKit/View/Onboarding/OnboardingFinal.swift
+++ b/PostKit/PostKit/View/Onboarding/OnboardingFinal.swift
@@ -12,24 +12,21 @@ struct OnboardingFinal: View {
     @ObservedObject var onboardingRouter = OnboardingRouter.shared
     @Binding var isFirstLaunching: Bool
     var body: some View {
-        VStack {
-            VStack {
-                OnboardingCustomHeader(action: onboardingRouter.previousPage)
-                    .padding(.horizontal,16)
+        VStack(alignment:.leading,spacing: 0) {
+            OnboardingCustomHeader(action: onboardingRouter.previousPage)
+            ContentArea {
+                VStack(alignment:.leading,spacing: 40) {
+                    Text("\(appstorageManager.cafeName) 사장님,\n반가워요👋")
+                        .font(.title1())
+                        .foregroundStyle(Color.gray6)
+                    Text("포스트킷과 함께\n카페 이야기를 적어내려가 봐요")
+                        .font(.body1Bold())
+                        .foregroundStyle(Color.gray4)
+                }
             }
-            VStack(alignment:.leading) {
-                Text("\(appstorageManager.cafeName) 사장님,\n반가워요👋")
-                    .font(.title1())
-                    .foregroundStyle(Color.gray6)
-                    .padding(.top,60)
-                Text("포스트킷과 함께\n카페 이야기를 적어내려가 봐요")
-                    .font(.body1Bold())
-                    .foregroundStyle(Color.gray4)
-                    .padding(.top,40)
-                Spacer()
-                CtaBtn(btnDescription:"확인", isActive: .constant(true), action: {isFirstLaunching.toggle()})
-            }
-            .padding(.horizontal,paddingHorizontal)
+            .padding(.top,paddingTop)
+            Spacer()
+            CtaBtn(btnDescription:"확인", isActive: .constant(true), action: {isFirstLaunching.toggle()})
         }
     }
 }

--- a/PostKit/PostKit/View/Onboarding/OnboardingIntro.swift
+++ b/PostKit/PostKit/View/Onboarding/OnboardingIntro.swift
@@ -25,7 +25,7 @@ struct OnboardingIntro: View {
             Spacer()
 
             VStack() {
-                CustomBtn(btnDescription: "시작하기", isActive: .constant(true), action: {onboardingRouter.nextPage();print(onboardingRouter.currentPage)})
+                CtaBtn(btnDescription: "시작하기", isActive: .constant(true), action: {onboardingRouter.nextPage();print(onboardingRouter.currentPage)})
             }
             .frame(alignment: .bottom)
         }

--- a/PostKit/PostKit/View/Onboarding/OnboardingIntro.swift
+++ b/PostKit/PostKit/View/Onboarding/OnboardingIntro.swift
@@ -12,28 +12,27 @@ struct OnboardingIntro: View {
     @ObservedObject var onboardingRouter = OnboardingRouter.shared
     
     var body: some View {
-        VStack(alignment: .leading) {
-            VStack(alignment: .leading,spacing: 30) {
-                Text("포스트킷과 함께\n우리 매장을 알려봐요")
-                    .font(.title1())
-                    .foregroundStyle(Color.gray6)
-                Text("포스트킷은 쉽고 빠르게 마케팅용 콘텐츠를 생성하는\n효과적인 인공지능 글쓰기 도구입니다.\n\n몇 번의 탭만으로\n생성하고 싶은 주제 대한 정보를 선택하고\n귀찮은 콘텐츠 생성 업무를 해결해보세요!")
-                    .font(.body1Bold())
-                    .foregroundStyle(Color.gray4)
+        
+        VStack(alignment: .leading,spacing: 0) {
+            ContentArea {
+                VStack(alignment: .leading,spacing: 30) {
+                    Text("포스트킷과 함께\n우리 매장을 알려봐요")
+                        .font(.title1())
+                        .foregroundStyle(Color.gray6)
+                        .padding(.top,100)
+                    Text("포스트킷은 쉽고 빠르게 마케팅용 콘텐츠를 생성하는\n효과적인 인공지능 글쓰기 도구입니다.\n\n몇 번의 탭만으로\n생성하고 싶은 주제 대한 정보를 선택하고\n귀찮은 콘텐츠 생성 업무를 해결해보세요!")
+                        .font(.body1Bold())
+                        .foregroundStyle(Color.gray4)
+    
+                }
             }
-            .padding(.top,120)
             Spacer()
-
-            VStack() {
-                CtaBtn(btnDescription: "시작하기", isActive: .constant(true), action: {onboardingRouter.nextPage();print(onboardingRouter.currentPage)})
-            }
-            .frame(alignment: .bottom)
+            CtaBtn(btnDescription: "시작하기", isActive: .constant(true), action: {onboardingRouter.nextPage();print(onboardingRouter.currentPage)})
         }
         .onAppear {
             appstorageManager.$cafeName.wrappedValue = ""
             appstorageManager.$cafeTone.wrappedValue = "기본"
         }
-        .padding(.horizontal,paddingHorizontal)
     }
 }
 

--- a/PostKit/PostKit/View/Onboarding/OnboardingStore.swift
+++ b/PostKit/PostKit/View/Onboarding/OnboardingStore.swift
@@ -43,7 +43,7 @@ struct OnboardingStore: View {
                 .padding(.top,20)
                 .padding(.bottom,80)
                 Spacer()
-                CustomBtn(btnDescription: "다음", isActive: $isActive, action: {onboardingRouter.nextPage()})
+                CtaBtn(btnDescription: "다음", isActive: $isActive, action: {onboardingRouter.nextPage()})
             }
             .padding(.horizontal,paddingHorizontal)
         }

--- a/PostKit/PostKit/View/Onboarding/OnboardingStore.swift
+++ b/PostKit/PostKit/View/Onboarding/OnboardingStore.swift
@@ -16,36 +16,32 @@ struct OnboardingStore: View {
     @ObservedObject var onboardingRouter = OnboardingRouter.shared
     @State private var isActive: Bool = false
     var body: some View {
-        VStack {
+        VStack(spacing: 0) {
             OnboardingCustomHeader(action: {onboardingRouter.previousPage()})
-                .padding(.horizontal,16)
-            VStack(alignment: .leading) {
-                VStack(alignment: .leading, spacing: 12) {
-                    Text("매장의 이름을 알려주세요")
-                        .font(.title1())
-                        .foregroundStyle(Color.gray6)
-                        .padding(.top,20)
-                    Text("매장에 더 잘 맞는 커피가 생성됩니다.")
-                        .font(.body2Bold())
-                        .foregroundStyle(Color.gray4)
-                        .padding(.top,12)
-                    CustomTextfield(textLimit: 15, menuName: $cafeName, placeHolder: "동글이 카페")
-                        .padding(.top,40)
-                    // cafeName이 비어있지 않으면 트루 OR false
-                        .onChange(of: $cafeName.wrappedValue) { lengthCount in
-                            if !lengthCount.isEmpty {
-                                isActive = true
-                            } else {
-                                isActive = false
+            ContentArea {
+                VStack(alignment:.leading,spacing: 40){
+                    VStack(alignment:.leading, spacing: 12) {
+                        Text("매장의 이름을 알려주세요")
+                            .font(.title1())
+                            .foregroundStyle(Color.gray6)
+                        Text("매장에 더 잘 맞는 커피가 생성됩니다.")
+                            .font(.body2Bold())
+                            .foregroundStyle(Color.gray4)
+                    }
+                    VStack(alignment: .leading) {
+                        CustomTextfield(textLimit: 15, menuName: $cafeName, placeHolder: "동글이 카페")
+                            .onChange(of: $cafeName.wrappedValue) { lengthCount in
+                                if !lengthCount.isEmpty {
+                                    isActive = true
+                                } else {
+                                    isActive = false
+                                }
                             }
-                        }
+                    }
                 }
-                .padding(.top,20)
-                .padding(.bottom,80)
-                Spacer()
-                CtaBtn(btnDescription: "다음", isActive: $isActive, action: {onboardingRouter.nextPage()})
             }
-            .padding(.horizontal,paddingHorizontal)
+            Spacer()
+            CtaBtn(btnDescription: "다음", isActive: $isActive, action: {onboardingRouter.nextPage()})
         }
     }
 }

--- a/PostKit/PostKit/View/Onboarding/OnboardingTone.swift
+++ b/PostKit/PostKit/View/Onboarding/OnboardingTone.swift
@@ -31,7 +31,7 @@ struct OnboardingTone: View {
                     SelectTone(tone: $cafeTone)
                         .padding(.top,40)
                     Spacer()
-                    CustomBtn(btnDescription: "다음", isActive: .constant(true), action: {onboardingRouter.nextPage()})
+                    CtaBtn(btnDescription: "다음", isActive: .constant(true), action: {onboardingRouter.nextPage()})
                 }
                 .padding(.horizontal,paddingHorizontal)
             }

--- a/PostKit/PostKit/View/Onboarding/OnboardingTone.swift
+++ b/PostKit/PostKit/View/Onboarding/OnboardingTone.swift
@@ -15,26 +15,27 @@ struct OnboardingTone: View {
     @Binding var cafeTone : String
     
     var body: some View {
-        VStack {
+        VStack(alignment:.leading,spacing: 0) {
             OnboardingCustomHeader(action: onboardingRouter.previousPage)
-                .padding(.horizontal,16)
-            VStack {
-                VStack(alignment: .leading) {
-                    Text("원하는 톤을 선택하세요")
-                        .font(.title1())
-                        .foregroundStyle(Color.gray6)
-                        .padding(.top,20)
-                    Text("선택한 톤을 바탕으로 카피가 생성됩니다.")
-                        .font(.body2Bold())
-                        .foregroundStyle(Color.gray4)
-                        .padding(.top,12)
+            ContentArea {
+                VStack(alignment: .leading,spacing: 40) {
+                    VStack(alignment: .leading,spacing: 12) {
+                        Text("원하는 톤을 선택하세요")
+                            .font(.title1())
+                            .foregroundStyle(Color.gray6)
+                            .padding(.top,20)
+                        Text("선택한 톤을 바탕으로 카피가 생성됩니다.")
+                            .font(.body2Bold())
+                            .foregroundStyle(Color.gray4)
+                            .padding(.top,12)
+                    }
                     SelectTone(tone: $cafeTone)
-                        .padding(.top,40)
-                    Spacer()
-                    CtaBtn(btnDescription: "다음", isActive: .constant(true), action: {onboardingRouter.nextPage()})
                 }
-                .padding(.horizontal,paddingHorizontal)
             }
+            
+            Spacer()
+
+            CtaBtn(btnDescription: "다음", isActive: .constant(true), action: {onboardingRouter.nextPage()})
         }
     }
 }

--- a/PostKit/PostKit/View/Setting/SettingStoreView.swift
+++ b/PostKit/PostKit/View/Setting/SettingStoreView.swift
@@ -29,7 +29,7 @@ struct SettingStoreView: View {
                 CustomTextfield(textLimit: 15, menuName: $storeName, placeHolder: storeName)
                     .padding(.top,12)
                 Spacer()
-                CustomBtn(btnDescription: "저장", isActive: .constant(true), action: {
+                CtaBtn(btnDescription: "저장", isActive: .constant(true), action: {
                     saveStoreData(storeName: storeName, storeTone: storeTone)
                 })
             }

--- a/PostKit/PostKit/View/Setting/SettingToneView.swift
+++ b/PostKit/PostKit/View/Setting/SettingToneView.swift
@@ -30,7 +30,7 @@ struct SettingToneView: View {
             VStack {
                 toggleBtns
                 Spacer()
-                CustomBtn(btnDescription: "저장", isActive: .constant(true)) {
+                CtaBtn(btnDescription: "저장", isActive: .constant(true)) {
                     pathManager.path.removeLast()
                     saveStoreData(storeName: storeName, storeTone: storeTone)
                 }


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->

## Task TODOLIST
- [x] Viewbuilder를 이용한 미리 padding값을 적용한 컴포넌트 만들기 ContentArea()
- [x] 기본 컴포넌트들을 리펙토링 

## ✨ 개발 내용
<!-- 개발에 대한 내용을 적어주세요 -->
이런식의 적용으로 현재 만들어진 뷰들에 적용하고 나머지 뷰들에도 적용시키면 피그마에 패딩값을 못맞추는 휴먼에러가 나지 않을 것 같아요
```
import SwiftUI

//MARK: Padding값을 미리 적용해서 ContentArea라는 ViewBuilder를 만들어서 이제 따로 전체 패딩값을 주지 않아도 됩니다.
struct ContentArea<T: View>: View {
    let content: T
    
    init(@ViewBuilder content: () -> T) {
           self.content = content()
       }
    
    var body: some View {
            content
                .padding(.horizontal,paddingHorizontal)
                .padding(.top,paddingTop)
                .padding(.bottom,paddingBottom)

    }
}

//CustomVstack을 활용한 뷰 예시
import SwiftUI

struct SampleView: View {
    var body: some View {
        VStack {
            ContentArea {
                VStack(spacing:40) {
                    Rectangle()
                        .frame(height: 30)
                    Rectangle()
                        .frame(height: 30)
                    
                }
                .border(.blue)
            }
            .border(.red)
            CtaBtn(btnDescription: "dd", isActive: .constant(true), action: {print("")})
        }
    }
}
```
실제로 변경된 코드 예시
Header부분과 CotentArea BtnArea (가칭)으로 분리하여 제작한다고 생각하시면 될 것 같습니다.
```

import SwiftUI

struct OnboardingTone: View {
    //@EnvironmentObject var appstorageManager: AppstorageManager
    @ObservedObject var onboardingRouter = OnboardingRouter.shared
    
    //Core Data 저장을 위해 가지고 나가기
    @Binding var cafeTone : String
    
    var body: some View {
        VStack(alignment:.leading,spacing: 0) {
            OnboardingCustomHeader(action: onboardingRouter.previousPage)
            ContentArea {
                VStack(alignment: .leading,spacing: 40) {
                    VStack(alignment: .leading,spacing: 12) {
                        Text("원하는 톤을 선택하세요")
                            .font(.title1())
                            .foregroundStyle(Color.gray6)
                            .padding(.top,20)
                        Text("선택한 톤을 바탕으로 카피가 생성됩니다.")
                            .font(.body2Bold())
                            .foregroundStyle(Color.gray4)
                            .padding(.top,12)
                    }
                    SelectTone(tone: $cafeTone)
                }
            }
            
            Spacer()

            CtaBtn(btnDescription: "다음", isActive: .constant(true), action: {onboardingRouter.nextPage()})
        }
    }
}

```
## 📸 스크린샷(선택)

<img src = "https://github.com/ADA-RLD/PostKit/assets/84852135/ea7f7e8a-39eb-4d87-b826-49d94357dd94" width="50%">
