### PR TITLE
Rash fix/#82

### DIFF
--- a/PostKit/PostKit.xcodeproj/project.pbxproj
+++ b/PostKit/PostKit.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		139B2C7E2ADFF8690036BD18 /* ContentArea.swift in Sources */ = {isa = PBXBuildFile; fileRef = 139B2C7D2ADFF8690036BD18 /* ContentArea.swift */; };
+		139B2C822AE9359D0036BD18 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 139B2C812AE9359D0036BD18 /* Constants.swift */; };
 		13C295B12AD55F2100A2DE7F /* PostKitApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13C295B02AD55F2100A2DE7F /* PostKitApp.swift */; };
 		13C295B52AD55F2200A2DE7F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13C295B42AD55F2200A2DE7F /* Assets.xcassets */; };
 		13C295B82AD55F2200A2DE7F /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13C295B72AD55F2200A2DE7F /* Preview Assets.xcassets */; };
@@ -37,7 +38,6 @@
 		13C2961A2AD8F26300A2DE7F /* SelectTone.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13C296192AD8F26300A2DE7F /* SelectTone.swift */; };
 		13C2961C2AD8F32000A2DE7F /* ToneModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13C2961B2AD8F32000A2DE7F /* ToneModel.swift */; };
 		13C296242AD988FC00A2DE7F /* AppStorageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13C296232AD988FC00A2DE7F /* AppStorageManager.swift */; };
-		13C2962B2ADF88D600A2DE7F /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13C2962A2ADF88D600A2DE7F /* Constants.swift */; };
 		6EF76458DDB4A8411EF377DE /* Pods_PostKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DE6BE08B166896FD0EC1F6B1 /* Pods_PostKit.framework */; };
 		7EF314CC2AD81DC3008E7338 /* ChatGptService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EF314CB2AD81DC3008E7338 /* ChatGptService.swift */; };
 		7EF314CE2AD81DE3008E7338 /* ChatGptModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EF314CD2AD81DE3008E7338 /* ChatGptModel.swift */; };
@@ -68,6 +68,7 @@
 /* Begin PBXFileReference section */
 		0A14ED0B2AD96D9A00357A79 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		139B2C7D2ADFF8690036BD18 /* ContentArea.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentArea.swift; sourceTree = "<group>"; };
+		139B2C812AE9359D0036BD18 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		13C295AD2AD55F2100A2DE7F /* PostKit.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PostKit.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13C295B02AD55F2100A2DE7F /* PostKitApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostKitApp.swift; sourceTree = "<group>"; };
 		13C295B42AD55F2200A2DE7F /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -100,7 +101,6 @@
 		13C2961B2AD8F32000A2DE7F /* ToneModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToneModel.swift; sourceTree = "<group>"; };
 		13C2961D2AD9734800A2DE7F /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		13C296232AD988FC00A2DE7F /* AppStorageManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStorageManager.swift; sourceTree = "<group>"; };
-		13C2962A2ADF88D600A2DE7F /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		3E68A9EB98B7C9C0E4C2479A /* Pods-PostKit.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PostKit.release.xcconfig"; path = "Target Support Files/Pods-PostKit/Pods-PostKit.release.xcconfig"; sourceTree = "<group>"; };
 		7EF314CB2AD81DC3008E7338 /* ChatGptService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatGptService.swift; sourceTree = "<group>"; };
 		7EF314CD2AD81DE3008E7338 /* ChatGptModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatGptModel.swift; sourceTree = "<group>"; };
@@ -211,7 +211,7 @@
 				7EF314CD2AD81DE3008E7338 /* ChatGptModel.swift */,
 				13C2961B2AD8F32000A2DE7F /* ToneModel.swift */,
 				13C296232AD988FC00A2DE7F /* AppStorageManager.swift */,
-				13C2962A2ADF88D600A2DE7F /* Constants.swift */,
+				139B2C812AE9359D0036BD18 /* Constants.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -470,7 +470,6 @@
 				B986326C2AD7E76200DE9FF5 /* CaptionResultView.swift in Sources */,
 				B986326A2AD7D13400DE9FF5 /* KeyboardObserver.swift in Sources */,
 				B986327C2ADA5DC300DE9FF5 /* LoadingView.swift in Sources */,
-				13C2962B2ADF88D600A2DE7F /* Constants.swift in Sources */,
 				A188C57F2AD7B822007473D3 /* CoreData.xcdatamodeld in Sources */,
 				B98632782AD9735000DE9FF5 /* DailyView.swift in Sources */,
 				A188C5772AD79E0E007473D3 /* MenuModel.swift in Sources */,
@@ -485,6 +484,7 @@
 				13C2961C2AD8F32000A2DE7F /* ToneModel.swift in Sources */,
 				13C295DA2AD68BF600A2DE7F /* SettingToneView.swift in Sources */,
 				13C296182AD8F1F000A2DE7F /* CustomHeader.swift in Sources */,
+				139B2C822AE9359D0036BD18 /* Constants.swift in Sources */,
 				B98632622AD7CFD500DE9FF5 /* CustomTextfield.swift in Sources */,
 				A188C5812AD7BA1E007473D3 /* DailyDataManager.swift in Sources */,
 				13C295D52AD677FA00A2DE7F /* NavigationModel.swift in Sources */,

--- a/PostKit/PostKit/View/Caption/DailyView.swift
+++ b/PostKit/PostKit/View/Caption/DailyView.swift
@@ -115,7 +115,7 @@ struct DailyView: View {
                 .scrollIndicators(.hidden)
             }
         }
-        CtaBtn(btnLabel: "카피 생성", isActive: .constant(true), action: {
+        CTABtn(btnLabel: "카피 생성", isActive: .constant(true), action: {
             sendMessage()
             pathManager.path.append(.CaptionResult)
         })

--- a/PostKit/PostKit/View/Caption/MenuView.swift
+++ b/PostKit/PostKit/View/Caption/MenuView.swift
@@ -116,9 +116,9 @@ struct MenuView: View {
         Task{
             var pointText = ""
             if storeModel.tone == "기본"{
-                self.messages.append(Message(id: UUID(), role: .system, content: "너는 \($storeModel.storeName)를 운영하고 있으며 평범한 말투를 가지고 있어. 글은 존댓말로 작성해줘. 글은 600자 정도로 작성해줘."))
+                self.messages.append(Message(id: UUID(), role: .system, content: "너는 \($storeModel.storeName)를 운영하고 있으며 평범한 말투를 가지고 있어. 글은 존댓말로 작성해줘. 글은 300자 정도로 작성해줘."))
             }else{
-                self.messages.append(Message(id: UUID(), role: .system, content: "너는 \($storeModel.storeName)를 운영하고 있으며 \($storeModel.tone) 말투를 가지고 있어. 글은 존댓말로 작성해줘. 글은 600자 정도로 작성해줘."))
+                self.messages.append(Message(id: UUID(), role: .system, content: "너는 \($storeModel.storeName)를 운영하고 있으며 \($storeModel.tone) 말투를 가지고 있어. 글은 존댓말로 작성해줘. 글은 300자 정도로 작성해줘."))
             }
             if !coffeeSelected.isEmpty {
                 pointText = pointText + "이 메뉴의 특징으로는 "

--- a/PostKit/PostKit/View/Caption/MenuView.swift
+++ b/PostKit/PostKit/View/Caption/MenuView.swift
@@ -98,7 +98,7 @@ struct MenuView: View {
                 }
             }
             Spacer()
-            CtaBtn(btnLabel: "카피 생성", isActive: self.$isActive, action: {
+            CTABtn(btnLabel: "카피 생성", isActive: self.$isActive, action: {
                 if isActive == true {
                     sendMessage()
                     pathManager.path.append(.CaptionResult)

--- a/PostKit/PostKit/View/Component/CTABtn.swift
+++ b/PostKit/PostKit/View/Component/CTABtn.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 // TODO: 색상 에셋 추가되면 색 바꿔야 해요
-struct CtaBtn: View {
+struct CTABtn: View {
     var btnLabel: String
     @Binding var isActive: Bool
     var action: () -> Void

--- a/PostKit/PostKit/View/MainView.swift
+++ b/PostKit/PostKit/View/MainView.swift
@@ -11,8 +11,7 @@ import CoreData
 struct MainView: View {
     @AppStorage("_cafeName") var cafeName: String = ""
     
-//    @AppStorage("_isFirstLaunching") var isFirstLaunching: Bool = true
-    @State var isFirstLaunching: Bool = true
+    @AppStorage("_isFirstLaunching") var isFirstLaunching: Bool = true
     @EnvironmentObject var appstorageManager: AppstorageManager
     @EnvironmentObject var pathManager: PathManager
     @ObservedObject var viewModel = ChatGptViewModel.shared

--- a/PostKit/PostKit/View/Onboarding/OnboardingFinal.swift
+++ b/PostKit/PostKit/View/Onboarding/OnboardingFinal.swift
@@ -30,7 +30,7 @@ struct OnboardingFinal: View {
             }
             .padding(.top,40)
             Spacer()
-            CtaBtn(btnLabel:"확인", isActive: .constant(true), action: {isFirstLaunching.toggle()})
+            CTABtn(btnLabel:"확인", isActive: .constant(true), action: {isFirstLaunching.toggle()})
         }
     }
 }

--- a/PostKit/PostKit/View/Onboarding/OnboardingIntro.swift
+++ b/PostKit/PostKit/View/Onboarding/OnboardingIntro.swift
@@ -26,7 +26,7 @@ struct OnboardingIntro: View {
             }
             .padding(.top,100)
             Spacer()
-            CtaBtn(btnLabel: "시작하기", isActive: .constant(true), action: {onboardingRouter.nextPage();print(onboardingRouter.currentPage)})
+            CTABtn(btnLabel: "시작하기", isActive: .constant(true), action: {onboardingRouter.nextPage();print(onboardingRouter.currentPage)})
         }
         .onAppear {
             appstorageManager.$cafeName.wrappedValue = ""

--- a/PostKit/PostKit/View/Onboarding/OnboardingStore.swift
+++ b/PostKit/PostKit/View/Onboarding/OnboardingStore.swift
@@ -41,7 +41,7 @@ struct OnboardingStore: View {
                 }
             }
             Spacer()
-            CtaBtn(btnLabel: "다음", isActive: $isActive, action: {onboardingRouter.nextPage()})
+            CTABtn(btnLabel: "다음", isActive: $isActive, action: {onboardingRouter.nextPage()})
         }
     }
 }

--- a/PostKit/PostKit/View/Onboarding/OnboardingTone.swift
+++ b/PostKit/PostKit/View/Onboarding/OnboardingTone.swift
@@ -33,7 +33,7 @@ struct OnboardingTone: View {
             
             Spacer()
 
-            CtaBtn(btnLabel: "다음", isActive: .constant(true), action: {onboardingRouter.nextPage()})
+            CTABtn(btnLabel: "다음", isActive: .constant(true), action: {onboardingRouter.nextPage()})
         }
     }
 }

--- a/PostKit/PostKit/View/Onboarding/OnboardingView.swift
+++ b/PostKit/PostKit/View/Onboarding/OnboardingView.swift
@@ -19,14 +19,14 @@ struct OnboardingView: View {
     //CoreData Data Class
     @StateObject var storeModel : StoreModel
 
-    // TODO: 쇼케이스 끝나면 바꿔야 합니다.
+
     //CoreData 초기화
-//    init(isFirstLaunching: Binding<Bool>, storeModel: StoreModel) {
-//           self._isFirstLaunching = isFirstLaunching
-//           self._storeModel = StateObject(wrappedValue: storeModel)
-//           fetchStoreData()
-//       }
-//    
+    init(isFirstLaunching: Binding<Bool>, storeModel: StoreModel) {
+           self._isFirstLaunching = isFirstLaunching
+           self._storeModel = StateObject(wrappedValue: storeModel)
+           fetchStoreData()
+       }
+    
     var body: some View {
         VStack {
             if onboardingRouter.currentPage == 0 {

--- a/PostKit/PostKit/View/Setting/SettingStoreView.swift
+++ b/PostKit/PostKit/View/Setting/SettingStoreView.swift
@@ -31,7 +31,7 @@ struct SettingStoreView: View {
                 }
             }
             Spacer()
-            CtaBtn(btnLabel: "저장", isActive: .constant(true), action: {
+            CTABtn(btnLabel: "저장", isActive: .constant(true), action: {
                 saveStoreData(storeName: storeName, storeTone: storeTone)
                 pathManager.path.removeLast()
             })

--- a/PostKit/PostKit/View/Setting/SettingToneView.swift
+++ b/PostKit/PostKit/View/Setting/SettingToneView.swift
@@ -33,7 +33,7 @@ struct SettingToneView: View {
                 }
             }
             Spacer()
-            CtaBtn(btnLabel: "저장", isActive: .constant(true)) {
+            CTABtn(btnLabel: "저장", isActive: .constant(true)) {
                 saveStoreData(storeName: storeName, storeTone: storeTone)
                 pathManager.path.removeLast()
             }

--- a/PostKit/PostKit/ViewModel/ChatGptService.swift
+++ b/PostKit/PostKit/ViewModel/ChatGptService.swift
@@ -10,7 +10,7 @@ import Alamofire
 
 class ChatGptService {
     private let baseUrl = "https://api.openai.com/v1/chat/completions"
-    
+    // 키 오류를 대비해서 랜덤하게 키를 게속 바꿔줍니다.
     func getRandomKey() -> String {
         let randomIndex = Int.random(in: 0..<Constants.ChatGptAPIKey.count)
         return Constants.ChatGptAPIKey[randomIndex]

--- a/PostKit/PostKit/ViewModel/ChatGptService.swift
+++ b/PostKit/PostKit/ViewModel/ChatGptService.swift
@@ -11,12 +11,18 @@ import Alamofire
 class ChatGptService {
     private let baseUrl = "https://api.openai.com/v1/chat/completions"
     
+    func getRandomKey() -> String {
+        let randomIndex = Int.random(in: 0..<Constants.ChatGptAPIKey.count)
+        return Constants.ChatGptAPIKey[randomIndex]
+    }
+    
     func sendMessage(messages: [Message]) async -> chatGptResponse? {
         let openAIMessages = messages.map({chatGptMessage(role: .system, content: $0.content)})
-        
-        let body = chatGptBody(model: "gpt-4", messages: openAIMessages)
+        let randomKey = getRandomKey()
+        print(randomKey)
+        let body = chatGptBody(model: "gpt-3.5-turbo-0301", messages: openAIMessages)
         let headers: HTTPHeaders =  [
-            "Authorization" : "Bearer \(Constants.ChatGptAPIKey)"
+            "Authorization" : "Bearer \(randomKey)"
         ]
         
         return try? await AF.request(baseUrl, method: .post, parameters: body, encoder: .json, headers: headers).serializingDecodable(chatGptResponse.self).value

--- a/PostKit/PostKit/ViewModel/ChatGptService.swift
+++ b/PostKit/PostKit/ViewModel/ChatGptService.swift
@@ -19,7 +19,6 @@ class ChatGptService {
     func sendMessage(messages: [Message]) async -> chatGptResponse? {
         let openAIMessages = messages.map({chatGptMessage(role: .system, content: $0.content)})
         let randomKey = getRandomKey()
-        print(randomKey)
         let body = chatGptBody(model: "gpt-3.5-turbo-0301", messages: openAIMessages)
         let headers: HTTPHeaders =  [
             "Authorization" : "Bearer \(randomKey)"


### PR DESCRIPTION
## 📌 관련 이슈
#82 
closed #82 

## Task TODOLIST

- [x] 하나의 키에서 여러개의 키로 바꿔서 사용하게 하기
- [x] ChatGpt 사용 모델 바꾸기

## ✨ 개발 내용
키에 문제가 발생했을떄를 대비해서 여러개의 키를 배열로 받아놓고 api를 호출할때 마다 랜덤하게 api에 키를 건네줍니다.
```
import Foundation
import Alamofire

class ChatGptService {
    private let baseUrl = "https://api.openai.com/v1/chat/completions"
    // 키 오류를 대비해서 랜덤하게 키를 게속 바꿔줍니다.
    func getRandomKey() -> String {
        let randomIndex = Int.random(in: 0..<Constants.ChatGptAPIKey.count)
        return Constants.ChatGptAPIKey[randomIndex]
    }
    
    func sendMessage(messages: [Message]) async -> chatGptResponse? {
        let openAIMessages = messages.map({chatGptMessage(role: .system, content: $0.content)})
        let randomKey = getRandomKey()
        print(randomKey)
        let body = chatGptBody(model: "gpt-3.5-turbo-0301", messages: openAIMessages)
        let headers: HTTPHeaders =  [
            "Authorization" : "Bearer \(randomKey)"
        ]
        
        return try? await AF.request(baseUrl, method: .post, parameters: body, encoder: .json, headers: headers).serializingDecodable(chatGptResponse.self).value
    }
}

용) 혹은 궁금한 사항들
ChatGpt api는 원래 timeout오류가 자주난다.
https://community.openai.com/t/frequent-api-timeout-errors-recently/106903/4
