### PR TITLE
[Feat] 드래그제스처를 사용해서 뒤로가기 기능 추가

### DIFF
--- a/PostKit/PostKit.xcodeproj/project.pbxproj
+++ b/PostKit/PostKit.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		139B2C892AECF0CD0036BD18 /* ErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 139B2C882AECF0CD0036BD18 /* ErrorView.swift */; };
 		139B2C8B2AEF34890036BD18 /* HashtagResultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 139B2C8A2AEF34890036BD18 /* HashtagResultView.swift */; };
 		139B2C8D2AEF42390036BD18 /* HapticManger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 139B2C8C2AEF42390036BD18 /* HapticManger.swift */; };
+		139B2C8F2AF0B6030036BD18 /* Ex+UINaivgationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 139B2C8E2AF0B6030036BD18 /* Ex+UINaivgationController.swift */; };
 		13C295B12AD55F2100A2DE7F /* PostKitApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13C295B02AD55F2100A2DE7F /* PostKitApp.swift */; };
 		13C295B52AD55F2200A2DE7F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13C295B42AD55F2200A2DE7F /* Assets.xcassets */; };
 		13C295B82AD55F2200A2DE7F /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13C295B72AD55F2200A2DE7F /* Preview Assets.xcassets */; };
@@ -77,6 +78,7 @@
 		139B2C882AECF0CD0036BD18 /* ErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorView.swift; sourceTree = "<group>"; };
 		139B2C8A2AEF34890036BD18 /* HashtagResultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HashtagResultView.swift; sourceTree = "<group>"; };
 		139B2C8C2AEF42390036BD18 /* HapticManger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HapticManger.swift; sourceTree = "<group>"; };
+		139B2C8E2AF0B6030036BD18 /* Ex+UINaivgationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Ex+UINaivgationController.swift"; sourceTree = "<group>"; };
 		13C295AD2AD55F2100A2DE7F /* PostKit.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PostKit.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13C295B02AD55F2100A2DE7F /* PostKitApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostKitApp.swift; sourceTree = "<group>"; };
 		13C295B42AD55F2200A2DE7F /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -280,6 +282,7 @@
 			children = (
 				B98632652AD7D01500DE9FF5 /* WrappingHStack.swift */,
 				13C295DC2AD6B48400A2DE7F /* DesignSystem.swift */,
+				139B2C8E2AF0B6030036BD18 /* Ex+UINaivgationController.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -539,6 +542,7 @@
 				A188C5852AD7BA89007473D3 /* CoreDataManager.swift in Sources */,
 				13C295B12AD55F2100A2DE7F /* PostKitApp.swift in Sources */,
 				A188C5942ADE22FC007473D3 /* SettingProtocol.swift in Sources */,
+				139B2C8F2AF0B6030036BD18 /* Ex+UINaivgationController.swift in Sources */,
 				13C2960E2AD8F15E00A2DE7F /* OnboardingIntro.swift in Sources */,
 				A1B75AD22AEFE24100DFD343 /* HashtagModel.swift in Sources */,
 				A188C58A2AD7CDD3007473D3 /* MenuProtocol.swift in Sources */,

--- a/PostKit/PostKit/View/Extension/Ex+UINaivgationController.swift
+++ b/PostKit/PostKit/View/Extension/Ex+UINaivgationController.swift
@@ -1,0 +1,21 @@
+//
+//  Ex+UINaivgationController.swift
+//  PostKit
+//
+//  Created by 김다빈 on 10/31/23.
+//
+
+import SwiftUI
+
+extension UINavigationController : UINavigationControllerDelegate, UIGestureRecognizerDelegate {
+    open override func viewDidLoad() {
+        super.viewDidLoad()
+        interactivePopGestureRecognizer?.delegate = self
+        navigationBar.isHidden = true
+    }
+    
+    // MARK: Navigation Stack에 쌓인 뷰가 1개를 초과해야 제스처가 동작하도록
+    public func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        return viewControllers.count > 1
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
#118 
## Task TODOLIST
- [ ] 스와이프를 이용한 뒤로가기 제스쳐를 추가

## ✨ 개발 내용
스와이플 제스처를 사용한 뒤로가기 기능을 만들었어요
```swift
extension UINavigationController : UINavigationControllerDelegate, UIGestureRecognizerDelegate {
    open override func viewDidLoad() {
        super.viewDidLoad()
        interactivePopGestureRecognizer?.delegate = self
        navigationBar.isHidden = true
    }
    
    // MARK: Navigation Stack에 쌓인 뷰가 1개를 초과해야 제스처가 동작하도록
    public func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
        return viewControllers.count > 1
    }
}
```

## 📸 스크린샷(선택)
<img src = "https://github.com/ADA-RLD/PostKit/assets/84852135/8aa1401a-05dc-41d0-b160-b827a3e1d7c4" width="50%">