### PR TITLE
[Chore] - Chatgpt API 연결 구조 변경

### DIFF
--- a/PostKit/PostKit/View/Caption/CaptionResultView.swift
+++ b/PostKit/PostKit/View/Caption/CaptionResultView.swift
@@ -175,9 +175,9 @@ extension CaptionResultView {
                             print("Caption 생성이 무사히 완료되었습니다.")
                         }
                     },
-                    receiveValue:  { res in
-                        print("res: \(res)")
-                        guard let textResponse = res.choices.first?.message.content else {return}
+                    receiveValue:  { response in
+                        print("response: \(response)")
+                        guard let textResponse = response.choices.first?.message.content else {return}
                         
                         viewModel.promptAnswer = textResponse
                     }

--- a/PostKit/PostKit/View/Caption/CaptionResultView.swift
+++ b/PostKit/PostKit/View/Caption/CaptionResultView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 import CoreData
 import UIKit
+import Combine
 
 enum ActiveAlert {
     case first, second
@@ -21,6 +22,7 @@ struct CaptionResultView: View {
     @State private var messages: [Message] = []
     @State private var isPresented: Bool = false
     @State private var activeAlert: ActiveAlert = .first
+    @State private var cancellables = Set<AnyCancellable>()
     @ObservedObject var viewModel = ChatGptViewModel.shared
     @ObservedObject var coinManager = CoinManager.shared
     
@@ -161,9 +163,26 @@ extension CaptionResultView {
             }
             let newMessage = Message(id: UUID(), role: .user, content: viewModel.prompt)
             self.messages.append(newMessage)
-            let response = await chatGptService.sendMessage(messages: self.messages)
-            print(response as Any)
-            viewModel.promptAnswer = response?.choices.first?.message.content == nil ? "" : response!.choices.first!.message.content
+
+            chatGptService.sendMessage(messages: self.messages)
+                .sink(
+                    receiveCompletion: { completion in
+                        switch completion {
+                        case .failure(let error):
+                            // TODO: - 오류 코드를 기반으로 오류 처리 진행 필요
+                            print("error 발생. error code: \(error._code)")
+                        case .finished:
+                            print("Caption 생성이 무사히 완료되었습니다.")
+                        }
+                    },
+                    receiveValue:  { res in
+                        print("res: \(res)")
+                        guard let textResponse = res.choices.first?.message.content else {return}
+                        
+                        viewModel.promptAnswer = textResponse
+                    }
+                )
+                .store(in: &cancellables)
         }
     }
     

--- a/PostKit/PostKit/View/Caption/DailyView.swift
+++ b/PostKit/PostKit/View/Caption/DailyView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import CoreData
+import Combine
 
 struct DailyView: View {
     @EnvironmentObject var pathManager: PathManager
@@ -28,6 +29,8 @@ struct DailyView: View {
     
     @State var messages: [Message] = []
     @State var currentInput: String = ""
+    @State var cancellables = Set<AnyCancellable>()
+    
     let chatGptService = ChatGptService()
     
     var body: some View {
@@ -40,15 +43,12 @@ struct DailyView: View {
                             .font(.body2Bold())
                             .foregroundStyle(Color.gray4)
                         
-                        
-                        
                         VStack(alignment:.leading, spacing: 24) {
-                            
-                            
                             VStack(alignment: .leading, spacing: 12) {
                                 Text("날씨 / 계절")
                                     .foregroundStyle(Color.gray5)
                                     .font(.body1Bold())
+                                
                                 Keywords(keyName: KeywordsModel().weatherKeys , selectedIndices: self.$weatherSelected)
                                     .frame(height: isContentsOpened[0] ? 180 : 80)
                                 

--- a/PostKit/PostKit/View/Caption/MenuView.swift
+++ b/PostKit/PostKit/View/Caption/MenuView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import CoreData
+import Combine
 
 struct MenuView: View {
     //@EnvironmentObject var appstorageManager: AppstorageManager
@@ -29,6 +30,7 @@ struct MenuView: View {
     
     @State var messages: [Message] = []
     @State var currentInput: String = ""
+    @State var cancellables = Set<AnyCancellable>()
     
     let chatGptService = ChatGptService()
     

--- a/PostKit/PostKit/ViewModel/ChatGptService.swift
+++ b/PostKit/PostKit/ViewModel/ChatGptService.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import Alamofire
+import Combine
 
 class ChatGptService {
     private let baseUrl = "https://api.openai.com/v1/chat/completions"
@@ -16,45 +17,32 @@ class ChatGptService {
         return Constants.ChatGptAPIKey[randomIndex]
     }
     
-    func sendMessage(messages: [Message]) async -> chatGptResponse? {
+    func sendMessage(messages: [Message]) -> AnyPublisher<chatGptResponse, Error> {
         let openAIMessages = messages.map({chatGptMessage(role: .user, content: $0.content)})
         let randomKey = getRandomKey()
-        // TODO : - 개발을 진행하는 동안 3.5로 진행하고 이후 배포시 4.0으로 상향 조정할 예정
+        // TODO: - 개발을 진행하는 동안 3.5로 진행하고 이후 배포시 4.0으로 상향 조정할 예정
         let body = chatGptBody(model: "gpt-3.5-turbo", messages: openAIMessages)
         let headers: HTTPHeaders =  [
             "Authorization" : "Bearer \(randomKey)"
         ]
         
-        do {
-            // TODO : - Configuration을 설정하여 timeout 별도로 설정할 예정
-            let response = try? await AF.request(baseUrl, method: .post, parameters: body, encoder: .json, headers: headers)
-                .serializingDecodable(chatGptResponse.self)
-                .value
-            
-            print("response: ")
-            print(response as Any)
-            
-            if response == nil {
-                throw ResponseError.noResponse
-            }
-            
-            return response
-        } 
-        catch {
-            print("error: \(error)")
-            // MARK: - Chat Gpt 에러 처리
-            if error._code == NSURLErrorTimedOut {
-                print("Time Out Error 발생")
-                return chatGptResponse(choices: [chatGptChoice(finish_reason: "", message: chatGptMessage(role: .system, content: "TIMEOUT"))])
-            }
-            else if error as! ResponseError == ResponseError.noResponse {
-                print("Nil Response Error 발생")
-                return chatGptResponse(choices: [chatGptChoice(finish_reason: "", message: chatGptMessage(role: .system, content: "NILError"))])
-            }
-            else {
-                print("error: \(error) Server Error 발생")
-                return chatGptResponse(choices: [chatGptChoice(finish_reason: "", message: chatGptMessage(role: .system, content: "ServerError"))])
-            }
+        return Future <chatGptResponse, Error>{ promise in
+            AF.request(self.baseUrl, method: .post, parameters: body, encoder: .json, headers: headers)
+                .responseDecodable(of: chatGptResponse.self) { response in
+                    switch response.result {
+                    case .success(let result):
+                        print("success: \(result)")
+                        promise(.success(result))
+                    case .failure(let error):
+                        print("error 상세 내용: \(error)")
+                        print("error_code: \(error._code)")
+                        // error code 별 오류
+                        // 10: keyNotFound - choices string not found: nil 값 error
+                        // 13: InternetNotFound - offline인 상태로 인해 error 발생
+                        promise(.failure(error))
+                    }
+                }
         }
+        .eraseToAnyPublisher()
     }
 }

--- a/PostKit/PostKit/ViewModel/DailyViewModel.swift
+++ b/PostKit/PostKit/ViewModel/DailyViewModel.swift
@@ -93,7 +93,7 @@ extension DailyView {
                     guard let textResponse = response.choices.first?.message.content else {return}
                     
                     viewModel.promptAnswer = textResponse
-                    viewModel.category = "메뉴"
+                    viewModel.category = "일상"
                 }
             )
             .store(in: &cancellables)

--- a/PostKit/PostKit/ViewModel/DailyViewModel.swift
+++ b/PostKit/PostKit/ViewModel/DailyViewModel.swift
@@ -88,9 +88,9 @@ extension DailyView {
                         print("Caption 생성이 무사히 완료되었습니다.")
                     }
                 },
-                receiveValue:  { res in
-                    print("res: \(res)")
-                    guard let textResponse = res.choices.first?.message.content else {return}
+                receiveValue:  { response in
+                    print("response: \(response)")
+                    guard let textResponse = response.choices.first?.message.content else {return}
                     
                     viewModel.promptAnswer = textResponse
                     viewModel.category = "메뉴"

--- a/PostKit/PostKit/ViewModel/MenuViewModel.swift
+++ b/PostKit/PostKit/ViewModel/MenuViewModel.swift
@@ -84,9 +84,9 @@ extension MenuView {
                         print("Caption 생성이 무사히 완료되었습니다.")
                     }
                 },
-                receiveValue:  { res in
-                    print("res: \(res)")
-                    guard let textResponse = res.choices.first?.message.content else {return}
+                receiveValue:  { response in
+                    print("response: \(response)")
+                    guard let textResponse = response.choices.first?.message.content else {return}
                     
                     viewModel.promptAnswer = textResponse
                     viewModel.category = "메뉴"

--- a/PostKit/PostKit/ViewModel/MenuViewModel.swift
+++ b/PostKit/PostKit/ViewModel/MenuViewModel.swift
@@ -13,7 +13,7 @@ extension MenuView {
         Task{
             createPrompt(coffeeSelected: coffeeSelected, dessertSelected: dessertSelected, drinkSelected: drinkSelected, menuName: menuName)
             self.messages.append(Message(id: UUID(), role: .user, content: self.currentInput))
-            await createCaption()
+            createCaption()
         }
     }
     
@@ -37,7 +37,7 @@ extension MenuView {
         self.messages.append(Message(id: UUID(), role: .system, content:"너는 \(storeModel.storeName)를 운영하고 있으며 \(toneInfo)한 말투를 가지고 있어. 글은 존댓말로 작성해줘. 다른 부연 설명은 하지 말고 응답 내용만 작성해줘. 글자수는 꼭 150자 정도로 작성해줘."))
         
         print("[생성 정보]\n너는 \(storeModel.storeName)를 운영하고 있으며 \(toneInfo)한 말투를 가지고 있어. 글은 존댓말로 작성해줘. 다른 부연 설명은 하지 말고 응답 내용만 작성해줘. 글자수는 꼭 150자 정도로 작성해줘.")
-
+        
         if !coffeeSelected.isEmpty {
             pointText = pointText + "이 메뉴의 특징으로는 "
             
@@ -70,13 +70,28 @@ extension MenuView {
     }
     
     // MARK: - Caption 생성
-    func createCaption() async{
+    func createCaption() {
         viewModel.prompt = self.currentInput
         self.currentInput = ""
-        let response = await chatGptService.sendMessage(messages: self.messages)
-        viewModel.promptAnswer = response?.choices.first?.message.content == nil ? "" : response!.choices.first!.message.content
-        viewModel.category = "메뉴"
-        
-        print(response as Any)
+        chatGptService.sendMessage(messages: self.messages)
+            .sink(
+                receiveCompletion: { completion in
+                    switch completion {
+                    case .failure(let error):
+                        // TODO: - 오류 코드를 기반으로 오류 처리 진행 필요
+                        print("error 발생. error code: \(error._code)")
+                    case .finished:
+                        print("Caption 생성이 무사히 완료되었습니다.")
+                    }
+                },
+                receiveValue:  { res in
+                    print("res: \(res)")
+                    guard let textResponse = res.choices.first?.message.content else {return}
+                    
+                    viewModel.promptAnswer = textResponse
+                    viewModel.category = "메뉴"
+                }
+            )
+            .store(in: &cancellables)
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #158 

## Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요! -->
- [x] Future-promise 구조로의 변화
- [x] 에러 처리 세부적으로 진행

## ✨ 개발 내용
<!-- 개발에 대한 내용을 적어주세요 -->
future - promise를 이용해 ChatGpt API 연결 진행
``` swift
return Future <chatGptResponse, Error>{ promise in
    AF.request(self.baseUrl, method: .post, parameters: body, encoder: .json, headers: headers)
        .responseDecodable(of: chatGptResponse.self) { response in
            switch response.result {
            case .success(let result):
                print("success: \(result)")
                promise(.success(result))
            case .failure(let error):
                print("error 상세 내용: \(error)")
                print("error_code: \(error._code)")
                // error code 별 오류
                // 10: keyNotFound - choices string not found: nil 값 error
                // 13: InternetNotFound - offline인 상태로 인해 error 발생
                promise(.failure(error))
            }
        }
}
.eraseToAnyPublisher()
```

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
이제 에러 내용 확인이 보다 용이해 졌습니다! 이후 개발에 다음 에러 코드를 참고해 주세요!
### [ error code 별 오류 ]
- 10: keyNotFound - nil 값일때 발생하는 error
- 13: InternetNotFound - offline인 상태일 때 발생하는 error