### PR TITLE
[Fix/#252] 온보딩 말투 뷰에서 이탈하면 선택된 말투가 초기화되는 버그

### DIFF
--- a/PostKit/PostKit/View/Onboarding/OnboardingTone.swift
+++ b/PostKit/PostKit/View/Onboarding/OnboardingTone.swift
@@ -46,7 +46,8 @@ struct OnboardingTone: View {
                 .background(Color.white)
             }.frame(maxHeight: .infinity, alignment: .bottom)
         }
-        .onAppear{cafeTone.removeAll()}
+        //저번에는 안됬었는데 왜 될까요?
+        //.onAppear{cafeTone.removeAll()}
     }
 }
 

--- a/PostKit/PostKit/View/Onboarding/OnboardingTone.swift
+++ b/PostKit/PostKit/View/Onboarding/OnboardingTone.swift
@@ -46,7 +46,6 @@ struct OnboardingTone: View {
                 .background(Color.white)
             }.frame(maxHeight: .infinity, alignment: .bottom)
         }
-        //저번에는 안됬었는데 왜 될까요?
         //.onAppear{cafeTone.removeAll()}
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 --> #252

## Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요! -->
- [x] 온보딩 말투 뷰에서 이탈하면 선택된 말투가 초기화되는 버그

## ✨ 개발 내용
<!-- 개발에 대한 내용을 적어주세요 -->
```온보딩 말투 뷰에서 이탈하면 선택된 말투가 초기화되는 버그```

##  TroubleShotting
<!-- TroubleShotting이 있었다면 이야기 해주세요! -->
```저번 버그 수정에 사용했던 onAppear를 삭제하니 작동하네요.```
