### PR TITLE
[Feat/#287] gpt api 변경

### DIFF
--- a/PostKit/PostKit.xcodeproj/project.pbxproj
+++ b/PostKit/PostKit.xcodeproj/project.pbxproj
@@ -49,6 +49,9 @@
 		139B2C8D2AEF42390036BD18 /* HapticManger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 139B2C8C2AEF42390036BD18 /* HapticManger.swift */; };
 		139B2C8F2AF0B6030036BD18 /* Ex+UINaivgationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 139B2C8E2AF0B6030036BD18 /* Ex+UINaivgationController.swift */; };
 		139B2C932AF23D690036BD18 /* CoinManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 139B2C922AF23D680036BD18 /* CoinManager.swift */; };
+		13BDD1482B738A440030AB02 /* ChatGptVisionModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13BDD1472B738A440030AB02 /* ChatGptVisionModel.swift */; };
+		13BDD14A2B738A650030AB02 /* GptVIsionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13BDD1492B738A650030AB02 /* GptVIsionViewModel.swift */; };
+		13BDD14C2B738A8C0030AB02 /* GptVisionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13BDD14B2B738A8C0030AB02 /* GptVisionService.swift */; };
 		13C295B12AD55F2100A2DE7F /* PostKitApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13C295B02AD55F2100A2DE7F /* PostKitApp.swift */; };
 		13C295B52AD55F2200A2DE7F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13C295B42AD55F2200A2DE7F /* Assets.xcassets */; };
 		13C295B82AD55F2200A2DE7F /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13C295B72AD55F2200A2DE7F /* Preview Assets.xcassets */; };
@@ -147,6 +150,9 @@
 		139B2C8C2AEF42390036BD18 /* HapticManger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HapticManger.swift; sourceTree = "<group>"; };
 		139B2C8E2AF0B6030036BD18 /* Ex+UINaivgationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Ex+UINaivgationController.swift"; sourceTree = "<group>"; };
 		139B2C922AF23D680036BD18 /* CoinManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoinManager.swift; sourceTree = "<group>"; };
+		13BDD1472B738A440030AB02 /* ChatGptVisionModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatGptVisionModel.swift; sourceTree = "<group>"; };
+		13BDD1492B738A650030AB02 /* GptVIsionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GptVIsionViewModel.swift; sourceTree = "<group>"; };
+		13BDD14B2B738A8C0030AB02 /* GptVisionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GptVisionService.swift; sourceTree = "<group>"; };
 		13C295AD2AD55F2100A2DE7F /* PostKit.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PostKit.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13C295B02AD55F2100A2DE7F /* PostKitApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostKitApp.swift; sourceTree = "<group>"; };
 		13C295B42AD55F2200A2DE7F /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -369,6 +375,7 @@
 				A1B75ACD2AEFB3EF00DFD343 /* CaptionModel.swift */,
 				A1B75AD12AEFE24100DFD343 /* HashtagModel.swift */,
 				A1B860AF2B60CEEE00D74BE1 /* ImagePicker.swift */,
+				13BDD1472B738A440030AB02 /* ChatGptVisionModel.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -394,6 +401,8 @@
 				137DF4E02AFBACB200571AD4 /* CopyManger.swift */,
 				13819EEA2B0303DC005E5D91 /* FirebaseManager.swift */,
 				133233012B6A720200A9A5CA /* GoodsViewModel.swift */,
+				13BDD1492B738A650030AB02 /* GptVIsionViewModel.swift */,
+				13BDD14B2B738A8C0030AB02 /* GptVisionService.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -731,6 +740,7 @@
 				139B2C8D2AEF42390036BD18 /* HapticManger.swift in Sources */,
 				7E06050E2AF22834003A87BC /* DailyViewModel.swift in Sources */,
 				A1B75ACE2AEFB3EF00DFD343 /* CaptionModel.swift in Sources */,
+				13BDD1482B738A440030AB02 /* ChatGptVisionModel.swift in Sources */,
 				B98632662AD7D01500DE9FF5 /* WrappingHStack.swift in Sources */,
 				13C295DF2AD6C01300A2DE7F /* CTABtn.swift in Sources */,
 				133232FE2B6121C800A9A5CA /* GoodsView.swift in Sources */,
@@ -753,6 +763,7 @@
 				13819F022B066D3A005E5D91 /* MyWebView.swift in Sources */,
 				A1A4FAF92AF6245400514053 /* iCloudProtocol.swift in Sources */,
 				1336DE5B2AF8D63B000A6D9A /* MainHistoryView.swift in Sources */,
+				13BDD14A2B738A650030AB02 /* GptVIsionViewModel.swift in Sources */,
 				B98632622AD7CFD500DE9FF5 /* CustomTextfield.swift in Sources */,
 				139B2C892AECF0CD0036BD18 /* ErrorView.swift in Sources */,
 				13C295D52AD677FA00A2DE7F /* NavigationModel.swift in Sources */,
@@ -760,6 +771,7 @@
 				B9872A3F2AF23D77000A795C /* HashtagPopover.swift in Sources */,
 				B9872A472AF394DA000A795C /* HistoryButton.swift in Sources */,
 				13ECB5092AF28C8B0046E6BE /* AppDelegate.swift in Sources */,
+				13BDD14C2B738A8C0030AB02 /* GptVisionService.swift in Sources */,
 				7EF314CC2AD81DC3008E7338 /* ChatGptService.swift in Sources */,
 				13C296102AD8F16700A2DE7F /* OnboardingRouter.swift in Sources */,
 				7EF314D22AD96A69008E7338 /* ChatGptViewModel.swift in Sources */,

--- a/PostKit/PostKit.xcodeproj/project.pbxproj
+++ b/PostKit/PostKit.xcodeproj/project.pbxproj
@@ -50,7 +50,6 @@
 		139B2C8F2AF0B6030036BD18 /* Ex+UINaivgationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 139B2C8E2AF0B6030036BD18 /* Ex+UINaivgationController.swift */; };
 		139B2C932AF23D690036BD18 /* CoinManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 139B2C922AF23D680036BD18 /* CoinManager.swift */; };
 		13BDD1482B738A440030AB02 /* ChatGptVisionModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13BDD1472B738A440030AB02 /* ChatGptVisionModel.swift */; };
-		13BDD14A2B738A650030AB02 /* GptVIsionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13BDD1492B738A650030AB02 /* GptVIsionViewModel.swift */; };
 		13BDD14C2B738A8C0030AB02 /* GptVisionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13BDD14B2B738A8C0030AB02 /* GptVisionService.swift */; };
 		13C295B12AD55F2100A2DE7F /* PostKitApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13C295B02AD55F2100A2DE7F /* PostKitApp.swift */; };
 		13C295B52AD55F2200A2DE7F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13C295B42AD55F2200A2DE7F /* Assets.xcassets */; };
@@ -151,7 +150,6 @@
 		139B2C8E2AF0B6030036BD18 /* Ex+UINaivgationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Ex+UINaivgationController.swift"; sourceTree = "<group>"; };
 		139B2C922AF23D680036BD18 /* CoinManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoinManager.swift; sourceTree = "<group>"; };
 		13BDD1472B738A440030AB02 /* ChatGptVisionModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatGptVisionModel.swift; sourceTree = "<group>"; };
-		13BDD1492B738A650030AB02 /* GptVIsionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GptVIsionViewModel.swift; sourceTree = "<group>"; };
 		13BDD14B2B738A8C0030AB02 /* GptVisionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GptVisionService.swift; sourceTree = "<group>"; };
 		13C295AD2AD55F2100A2DE7F /* PostKit.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PostKit.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13C295B02AD55F2100A2DE7F /* PostKitApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostKitApp.swift; sourceTree = "<group>"; };
@@ -401,7 +399,6 @@
 				137DF4E02AFBACB200571AD4 /* CopyManger.swift */,
 				13819EEA2B0303DC005E5D91 /* FirebaseManager.swift */,
 				133233012B6A720200A9A5CA /* GoodsViewModel.swift */,
-				13BDD1492B738A650030AB02 /* GptVIsionViewModel.swift */,
 				13BDD14B2B738A8C0030AB02 /* GptVisionService.swift */,
 			);
 			path = ViewModel;
@@ -763,7 +760,6 @@
 				13819F022B066D3A005E5D91 /* MyWebView.swift in Sources */,
 				A1A4FAF92AF6245400514053 /* iCloudProtocol.swift in Sources */,
 				1336DE5B2AF8D63B000A6D9A /* MainHistoryView.swift in Sources */,
-				13BDD14A2B738A650030AB02 /* GptVIsionViewModel.swift in Sources */,
 				B98632622AD7CFD500DE9FF5 /* CustomTextfield.swift in Sources */,
 				139B2C892AECF0CD0036BD18 /* ErrorView.swift in Sources */,
 				13C295D52AD677FA00A2DE7F /* NavigationModel.swift in Sources */,

--- a/PostKit/PostKit/Model/ChatGptVisionModel.swift
+++ b/PostKit/PostKit/Model/ChatGptVisionModel.swift
@@ -1,0 +1,8 @@
+//
+//  ChatGptVisionModel.swift
+//  PostKit
+//
+//  Created by 김다빈 on 2/7/24.
+//
+
+import Foundation

--- a/PostKit/PostKit/Model/ChatGptVisionModel.swift
+++ b/PostKit/PostKit/Model/ChatGptVisionModel.swift
@@ -15,8 +15,35 @@ struct ChatGptVisionBody: Encodable {
 
 struct GptVisionMessage: Codable {
     let role: SenderRole
-    let content: [GptVisionContent]
+    let content: Contents
 }
+
+enum Contents: Codable {
+    case string(String)
+    case array([GptVisionContent])
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let array = try? container.decode([GptVisionContent].self) {
+            self = .array(array)
+        } else if let string = try? container.decode(String.self) {
+            self = .string(string)
+        } else {
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "content data is not")
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .string(let string):
+            try container.encode(string)
+        case .array(let array):
+            try container.encode(array)
+        }
+    }
+}
+
 
 struct GptVisionContent: Codable {
     let type: String

--- a/PostKit/PostKit/Model/ChatGptVisionModel.swift
+++ b/PostKit/PostKit/Model/ChatGptVisionModel.swift
@@ -14,7 +14,6 @@ struct ChatGptVisionBody: Encodable {
 }
 
 struct GptVisionMessage: Codable {
-    let id: UUID
     let role: SenderRole
     let content: [GptVisionContent]
 }
@@ -30,10 +29,10 @@ struct ImageURL: Codable {
 }
 
 struct ChatGptVisionResponse: Decodable {
-    let choices: [chatGptChoice]
+    let choices: [ChatGptVisionChoice]
 }
 
-struct chatGptVisionChoice: Decodable {
+struct ChatGptVisionChoice: Decodable {
     let finish_reason: String
-    let message: chatGptMessage
+    let message: GptVisionMessage
 }

--- a/PostKit/PostKit/Model/ChatGptVisionModel.swift
+++ b/PostKit/PostKit/Model/ChatGptVisionModel.swift
@@ -6,3 +6,34 @@
 //
 
 import Foundation
+
+
+struct ChatGptVisionBody: Encodable {
+    let model: String
+    let messages: [GptVisionMessage]
+}
+
+struct GptVisionMessage: Codable {
+    let id: UUID
+    let role: SenderRole
+    let content: [GptVisionContent]
+}
+
+struct GptVisionContent: Codable {
+    let type: String
+    let text: String?
+    let image_url: ImageURL?
+}
+
+struct ImageURL: Codable {
+    let url: String
+}
+
+struct ChatGptVisionResponse: Decodable {
+    let choices: [chatGptChoice]
+}
+
+struct chatGptVisionChoice: Decodable {
+    let finish_reason: String
+    let message: chatGptMessage
+}

--- a/PostKit/PostKit/View/Caption/DailyView.swift
+++ b/PostKit/PostKit/View/Caption/DailyView.swift
@@ -94,7 +94,7 @@ extension DailyView {
                         loadingModel.isCaptionGenerate = false
                         loadingModel.inputArray = [isSelected, weatherSelected, dailyCoffeeSelected, dailyDessertSelected].flatMap { $0 }
                         loadingModel.inputArray = removeDuplicates(from: loadingModel.inputArray)
-                        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.8) {
+                        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 1.5) {
                             sendVisionMessage(weatherSelected: weatherSelected, dailyCoffeeSelected: dailyCoffeeSelected, dailyDessertSelected: dailyDessertSelected, customKeywords: customKeyword, textLength: textLengthArr[textLength], images: selectedImage)
                             print(coinManager.coin)
                         }

--- a/PostKit/PostKit/View/Caption/DailyView.swift
+++ b/PostKit/PostKit/View/Caption/DailyView.swift
@@ -60,7 +60,11 @@ struct DailyView: View {
                 }
             }
         .navigationBarBackButtonHidden()
+        .onAppear {
+            isActive = true
         }
+        }
+        
     }
 
 // MARK: View의 모둘화를 한 extension 모음입니다.

--- a/PostKit/PostKit/View/Caption/DailyView.swift
+++ b/PostKit/PostKit/View/Caption/DailyView.swift
@@ -27,6 +27,7 @@ struct DailyView: View {
     @State private var dailyDessertSelected: [String] = []
     @State private var customKeyword: [String] = []
     @State var messages: [Message] = []
+    @State var visionMessages: [GptVisionMessage] = []
     @State var cancellables = Set<AnyCancellable>()
     //CoreData Data Class
     @StateObject var storeModel : StoreModel
@@ -89,7 +90,15 @@ extension DailyView {
             if coinManager.coin >= CoinManager.captionCost {
                 pathManager.path.append(.Loading)
                 if selectedImage.count > 0 {
-                    
+                    Task {
+                        loadingModel.isCaptionGenerate = false
+                        loadingModel.inputArray = [isSelected, weatherSelected, dailyCoffeeSelected, dailyDessertSelected].flatMap { $0 }
+                        loadingModel.inputArray = removeDuplicates(from: loadingModel.inputArray)
+                        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.8) {
+                            sendVisionMessage(weatherSelected: weatherSelected, dailyCoffeeSelected: dailyCoffeeSelected, dailyDessertSelected: dailyDessertSelected, customKeywords: customKeyword, textLength: textLengthArr[textLength], images: selectedImage)
+                            print(coinManager.coin)
+                        }
+                    }
                 }
                 else {
                     Task{

--- a/PostKit/PostKit/View/Caption/DailyView.swift
+++ b/PostKit/PostKit/View/Caption/DailyView.swift
@@ -88,17 +88,22 @@ extension DailyView {
         CTABtn(btnLabel: "글 생성", isActive: $isActive, action: {
             if coinManager.coin >= CoinManager.captionCost {
                 pathManager.path.append(.Loading)
-              
-                Task{
-                    loadingModel.isCaptionGenerate = false
-                    //배열에 추가해서 가져갑니다.
-                    loadingModel.inputArray = [isSelected, weatherSelected, dailyCoffeeSelected, dailyDessertSelected].flatMap { $0 }
-                    loadingModel.inputArray = removeDuplicates(from: loadingModel.inputArray)
-                    DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.8) {
-                        sendMessage(weatherSelected: weatherSelected, dailyCoffeeSelected: dailyCoffeeSelected, dailyDessertSelected: dailyDessertSelected, customKeywords: customKeyword, textLength: textLengthArr[textLength])
-                        print(coinManager.coin)
+                if selectedImage.count > 0 {
+                    
+                }
+                else {
+                    Task{
+                        loadingModel.isCaptionGenerate = false
+                        //배열에 추가해서 가져갑니다.
+                        loadingModel.inputArray = [isSelected, weatherSelected, dailyCoffeeSelected, dailyDessertSelected].flatMap { $0 }
+                        loadingModel.inputArray = removeDuplicates(from: loadingModel.inputArray)
+                        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.8) {
+                            sendMessage(weatherSelected: weatherSelected, dailyCoffeeSelected: dailyCoffeeSelected, dailyDessertSelected: dailyDessertSelected, customKeywords: customKeyword, textLength: textLengthArr[textLength])
+                            print(coinManager.coin)
+                        }
                     }
                 }
+
             } else {
                 showAlert = true
             }

--- a/PostKit/PostKit/View/Caption/GoodsView.swift
+++ b/PostKit/PostKit/View/Caption/GoodsView.swift
@@ -110,16 +110,21 @@ extension GoodsView {
         CTABtn(btnLabel: "글 생성", isActive: $isActive, action: {
                 if coinManager.coin >= CoinManager.captionCost {
                     pathManager.path.append(.Loading)
-                    
-                    Task{
-                        loadingModel.isCaptionGenerate = false
-                        //선택된 옵션들을 가져갑니다.
-                        loadingModel.inputArray = [isSelected, coffeeSelected, dessertSelected, drinkSelected].flatMap { $0 }
-                        loadingModel.inputArray = removeDuplicates(from: loadingModel.inputArray)
-                        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.8) {
-                            sendMessage(coffeeSelected: coffeeSelected, dessertSelected: dessertSelected, drinkSelected: drinkSelected, menuName: menuName, customKeywords: customKeyword, textLenth: textLengthArr[textLength])
+                    if selectedImage.count >= 1 {
+                        
+                    }
+                    else {
+                        Task{
+                            loadingModel.isCaptionGenerate = false
+                            //선택된 옵션들을 가져갑니다.
+                            loadingModel.inputArray = [isSelected, coffeeSelected, dessertSelected, drinkSelected].flatMap { $0 }
+                            loadingModel.inputArray = removeDuplicates(from: loadingModel.inputArray)
+                            DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.8) {
+                                sendMessage(coffeeSelected: coffeeSelected, dessertSelected: dessertSelected, drinkSelected: drinkSelected, menuName: menuName, customKeywords: customKeyword, textLenth: textLengthArr[textLength])
+                            }
                         }
                     }
+
                 }
                 else {
                     showAlert = true

--- a/PostKit/PostKit/View/Caption/MenuView.swift
+++ b/PostKit/PostKit/View/Caption/MenuView.swift
@@ -111,13 +111,18 @@ extension MenuView {
                 if coinManager.coin >= CoinManager.captionCost {
                     pathManager.path.append(.Loading)
                     
-                    Task{
-                        loadingModel.isCaptionGenerate = false
-                        //선택된 옵션들을 가져갑니다.
-                        loadingModel.inputArray = [isSelected, coffeeSelected, dessertSelected, drinkSelected].flatMap { $0 }
-                        loadingModel.inputArray = removeDuplicates(from: loadingModel.inputArray)
-                        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.8) {
-                            sendMessage(coffeeSelected: coffeeSelected, dessertSelected: dessertSelected, drinkSelected: drinkSelected, menuName: menuName, customKeywords: customKeyword, textLenth: textLengthArr[textLength])
+                    if selectedImage.count >= 1 {
+                        
+                    }
+                    else {
+                        Task{
+                            loadingModel.isCaptionGenerate = false
+                            //선택된 옵션들을 가져갑니다.
+                            loadingModel.inputArray = [isSelected, coffeeSelected, dessertSelected, drinkSelected].flatMap { $0 }
+                            loadingModel.inputArray = removeDuplicates(from: loadingModel.inputArray)
+                            DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.8) {
+                                sendMessage(coffeeSelected: coffeeSelected, dessertSelected: dessertSelected, drinkSelected: drinkSelected, menuName: menuName, customKeywords: customKeyword, textLenth: textLengthArr[textLength])
+                            }
                         }
                     }
                 }

--- a/PostKit/PostKit/View/Component/KeywordAppend.swift
+++ b/PostKit/PostKit/View/Component/KeywordAppend.swift
@@ -18,6 +18,7 @@ struct KeywordAppend: View {
     @Binding var openPhoto : Bool
     @Binding var selectedImage : [UIImage]
     
+    
     var body: some View {
         VStack(alignment: .leading, spacing: 20) {
             HStack(spacing: 8) {

--- a/PostKit/PostKit/ViewModel/DailyViewModel.swift
+++ b/PostKit/PostKit/ViewModel/DailyViewModel.swift
@@ -47,9 +47,11 @@ extension DailyView {
             toneInfo = toneInfo.substring(from: 0, to: toneInfo.count-2)
         }
         
-        viewModel.basicPrompt = "너는 \(storeModel.storeName)를 운영하고 있으며 \(toneInfo) 말투를 가지고 있어. 그리고 같이 보낸 사진에 대해서도 설명해줘 글은 존댓말로 작성해줘. 다른 부연 설명은 하지 말고 응답 내용만 작성해줘. 글자수는 꼭 \(textLength)자로 맞춰서 작성해줘."
+        viewModel.basicPrompt = "보내준 사진에 대해서 한국말로 설명해줘"
         print(viewModel.basicPrompt)
-        self.messages.append(Message(id: UUID(), role: .system, content: viewModel.basicPrompt))
+        //        self.visionMessages.append(GptVisionMessage( role: .user, content: .array([GptVisionContent(type: "text", text: viewModel.prompt, image_url: nil)])))
+
+        self.visionMessages.append(GptVisionMessage( role: .user, content: .array([GptVisionContent(type: "text", text: viewModel.basicPrompt, image_url: nil)])))
         
         if !weatherSelected.isEmpty {
             pointText = pointText + "오늘 날씨의 특징으로는 "
@@ -95,8 +97,9 @@ extension DailyView {
             pointText = pointText + "이 있어."
         }
         
-        viewModel.prompt = "보내준 사진에 대한 설명과 카페 일상과 관련된 인스타그램 피드를 해시태그 없이 작성해줘.  \(pointText) 글자수는 공백 포함해서 꼭 \(textLength)자로 맞춰서 작성해줘."
-        self.visionMessages.append(GptVisionMessage( role: .user, content: .array([GptVisionContent(type: "text", text: viewModel.prompt, image_url: nil)])))
+//        viewModel.prompt = "보내준 사진에 대한 설명과 카페 일상과 관련된 인스타그램 피드를 해시태그 없이 작성해줘.  \(pointText) 글자수는 공백 포함해서 꼭 500자로 맞춰서 작성해줘."
+        print(viewModel.prompt)
+//        self.visionMessages.append(GptVisionMessage( role: .user, content: .array([GptVisionContent(type: "text", text: viewModel.prompt, image_url: nil)])))
 
    
     }
@@ -170,6 +173,7 @@ extension DailyView {
         }
         
         viewModel.prompt = "카페 일상과 관련된 인스타그램 피드를 해시태그 없이 작성해줘. \(pointText) 글자수는 공백 포함해서 꼭 \(textLength)자로 맞춰서 작성해줘."
+  
         self.messages.append(Message(id: UUID(), role: .user, content: viewModel.prompt))
     }
     
@@ -233,6 +237,7 @@ extension DailyView {
                 },
                 receiveValue: { response in
                     guard let choice = response.choices.first else { return }
+                    print(response)
 
                     // 선택지의 메시지를 가져옵니다.
                     let message = choice.message
@@ -247,6 +252,8 @@ extension DailyView {
 
                     viewModel.category = "일상"
                 }
+                
+                
 
             )
             .store(in: &cancellables)

--- a/PostKit/PostKit/ViewModel/DailyViewModel.swift
+++ b/PostKit/PostKit/ViewModel/DailyViewModel.swift
@@ -96,7 +96,7 @@ extension DailyView {
         }
         
         viewModel.prompt = "보내준 사진에 대한 설명과 카페 일상과 관련된 인스타그램 피드를 해시태그 없이 작성해줘.  \(pointText) 글자수는 공백 포함해서 꼭 \(textLength)자로 맞춰서 작성해줘."
-        self.visionMessages.append(GptVisionMessage( role: .user, content: [GptVisionContent(type: "text", text: viewModel.prompt, image_url: nil)]))
+        self.visionMessages.append(GptVisionMessage( role: .user, content: .array([GptVisionContent(type: "text", text: viewModel.prompt, image_url: nil)])))
 
    
     }
@@ -236,19 +236,18 @@ extension DailyView {
 
                     // 선택지의 메시지를 가져옵니다.
                     let message = choice.message
-                    print(choice.message)
-                    print("디코딩 ㅇ")
 
                     // 메시지에서 content를 가져옵니다.
                     let content = message.content
 
-                    // content를 사용하여 원하는 작업을 수행합니다.
-                    // 예: 텍스트 응답을 viewModel에 설정합니다.
-                    if let content = content.first {
-                        viewModel.promptAnswer = content.text ?? ""
+                    // content가 .string 케이스인 경우에 대한 처리
+                    if case let .string(text) = content {
+                        viewModel.promptAnswer = text
                     }
+
                     viewModel.category = "일상"
                 }
+
             )
             .store(in: &cancellables)
 
@@ -261,7 +260,7 @@ extension DailyView {
                 let base64String = imageData.base64EncodedString()
                 let imageUrl = "data:image/jpeg;base64,\(base64String)"
                 let imageContent = GptVisionContent(type: "image_url", text: nil, image_url: ImageURL(url: imageUrl))
-                let message = GptVisionMessage(role: .user, content: [imageContent])
+                let message = GptVisionMessage(role: .user, content: .array([imageContent]))
                 visionMessages.append(message)
             }
         }

--- a/PostKit/PostKit/ViewModel/DailyViewModel.swift
+++ b/PostKit/PostKit/ViewModel/DailyViewModel.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import Combine
+import UIKit
 
 extension DailyView {
     // MARK: - Chat Gpt API에 응답 요청
@@ -15,6 +16,89 @@ extension DailyView {
             createPrompt(weatherSelected: weatherSelected, dailyCoffeeSelected: dailyCoffeeSelected, dailyDessertSelected: dailyDessertSelected, customKeywords: customKeywords, textLength: textLength)
             await createCaption()
         }
+    }
+    
+    // MARK: - Vision API에 응답 요청
+    func sendVisionMessage(weatherSelected: [String], dailyCoffeeSelected: [String], dailyDessertSelected: [String], customKeywords: [String], textLength: Int, images: [UIImage]) {
+        Task {
+            createVisionPrompt(weatherSelected: weatherSelected, dailyCoffeeSelected: dailyCoffeeSelected, dailyDessertSelected: dailyDessertSelected, customKeywords: customKeywords, textLength: textLength, images: images)
+            await createVisionCaption(images: images)
+        }
+    }
+
+    // MARK: - Chat Gpt API에 사진을 포함한 Prompt 생성
+    func createVisionPrompt(weatherSelected: Array<String>, dailyCoffeeSelected: Array<String>, dailyDessertSelected: Array<String>, customKeywords: Array<String>, textLength: Int, images: [UIImage]) {
+        var pointText = ""
+        var toneInfo = ""
+        addImagesToMessages(images: images)
+        
+        for _tone in storeModel.tone {
+            if _tone == "" {
+                break
+            }
+            
+            toneInfo += _tone + ","
+        }
+        
+        if toneInfo == "" {
+            toneInfo = "평범한"
+        }
+        else {
+            toneInfo = toneInfo.substring(from: 0, to: toneInfo.count-2)
+        }
+        
+        viewModel.basicPrompt = "너는 \(storeModel.storeName)를 운영하고 있으며 \(toneInfo) 말투를 가지고 있어. 그리고 같이 보낸 사진에 대해서도 설명해줘 글은 존댓말로 작성해줘. 다른 부연 설명은 하지 말고 응답 내용만 작성해줘. 글자수는 꼭 \(textLength)자로 맞춰서 작성해줘."
+        print(viewModel.basicPrompt)
+        self.messages.append(Message(id: UUID(), role: .system, content: viewModel.basicPrompt))
+        
+        if !weatherSelected.isEmpty {
+            pointText = pointText + "오늘 날씨의 특징으로는 "
+            
+            for index in weatherSelected.indices {
+                pointText = pointText + "\(weatherSelected[index]), "
+            }
+            
+            pointText = pointText.substring(from: 0, to: pointText.count-2)
+            pointText = pointText + "이 있어."
+        }
+        
+        if !dailyCoffeeSelected.isEmpty {
+            pointText = pointText + "오늘 이야기하고자 하는 음료는 "
+            
+            for index in dailyCoffeeSelected.indices {
+                pointText = pointText + "\(dailyCoffeeSelected[index]), "
+            }
+            
+            pointText = pointText.substring(from: 0, to: pointText.count-2)
+            pointText = pointText + "이 있어."
+        }
+        
+        if !dailyDessertSelected.isEmpty {
+            pointText = pointText + "오늘 이야기하고자 하는 디저트는 "
+            
+            for index in dailyDessertSelected.indices {
+                pointText = pointText + "\(dailyDessertSelected[index]), "
+            }
+            
+            pointText = pointText.substring(from: 0, to: pointText.count-2)
+            pointText = pointText + "이 있어."
+        }
+        
+        if !customKeywords.isEmpty {
+            pointText = pointText + "특징으로는 "
+            
+            for index in customKeywords.indices {
+                pointText = pointText + "\(customKeywords[index]), "
+            }
+            
+            pointText = pointText.substring(from: 0, to: pointText.count-2)
+            pointText = pointText + "이 있어."
+        }
+        
+        viewModel.prompt = "보내준 사진에 대한 설명과 카페 일상과 관련된 인스타그램 피드를 해시태그 없이 작성해줘.  \(pointText) 글자수는 공백 포함해서 꼭 \(textLength)자로 맞춰서 작성해줘."
+        self.visionMessages.append(GptVisionMessage( role: .user, content: [GptVisionContent(type: "text", text: viewModel.prompt, image_url: nil)]))
+
+   
     }
     
     // MARK: - Prompt 생성
@@ -121,5 +205,65 @@ extension DailyView {
                 }
             )
             .store(in: &cancellables)
+    }
+    
+    func createVisionCaption(images: [UIImage]) {
+        let chatGptVisionService = GptVisionService()
+        
+        addImagesToMessages(images: images)
+        
+        chatGptVisionService.sendMessage(messages: self.visionMessages)
+            .sink(
+                receiveCompletion: { completion in
+                    switch completion {
+                    case .failure(let error):
+                        loadingModel.isCaptionGenerate = true
+                        print("error 발생. error code: \(error._code)")
+                        if error._code == 10 {
+                            pathManager.path.append(.ErrorResultFailed)
+                        } else if error._code == 13 {
+                            pathManager.path.append(.ErrorNetwork)
+                        }
+                    case .finished:
+                        loadingModel.isCaptionGenerate = false
+                        print("Caption 생성이 무사히 완료되었습니다.")
+                        pathManager.path.append(.CaptionResult)
+                        coinManager.coinCaptionUse()
+                    }
+                },
+                receiveValue: { response in
+                    guard let choice = response.choices.first else { return }
+
+                    // 선택지의 메시지를 가져옵니다.
+                    let message = choice.message
+                    print(choice.message)
+                    print("디코딩 ㅇ")
+
+                    // 메시지에서 content를 가져옵니다.
+                    let content = message.content
+
+                    // content를 사용하여 원하는 작업을 수행합니다.
+                    // 예: 텍스트 응답을 viewModel에 설정합니다.
+                    if let content = content.first {
+                        viewModel.promptAnswer = content.text ?? ""
+                    }
+                    viewModel.category = "일상"
+                }
+            )
+            .store(in: &cancellables)
+
+    }
+
+    // MARK: 이미지를 GPT 메세지에 추가하는 함수
+    private func addImagesToMessages(images: [UIImage]) {
+        for image in images {
+            if let imageData = image.jpegData(compressionQuality: 0.5) {
+                let base64String = imageData.base64EncodedString()
+                let imageUrl = "data:image/jpeg;base64,\(base64String)"
+                let imageContent = GptVisionContent(type: "image_url", text: nil, image_url: ImageURL(url: imageUrl))
+                let message = GptVisionMessage(role: .user, content: [imageContent])
+                visionMessages.append(message)
+            }
+        }
     }
 }

--- a/PostKit/PostKit/ViewModel/GptVIsionViewModel.swift
+++ b/PostKit/PostKit/ViewModel/GptVIsionViewModel.swift
@@ -1,0 +1,8 @@
+//
+//  GptVIsionViewModel.swift
+//  PostKit
+//
+//  Created by 김다빈 on 2/7/24.
+//
+
+import Foundation

--- a/PostKit/PostKit/ViewModel/GptVIsionViewModel.swift
+++ b/PostKit/PostKit/ViewModel/GptVIsionViewModel.swift
@@ -1,8 +1,0 @@
-//
-//  GptVIsionViewModel.swift
-//  PostKit
-//
-//  Created by 김다빈 on 2/7/24.
-//
-
-import Foundation

--- a/PostKit/PostKit/ViewModel/GptVisionService.swift
+++ b/PostKit/PostKit/ViewModel/GptVisionService.swift
@@ -6,3 +6,59 @@
 //
 
 import Foundation
+import Alamofire
+import Combine
+import SwiftUI
+
+class GptVisionService: ObservableObject {
+    static let shared = GptVisionService()
+    
+    @AppStorage("_isCanceled") var isCanceled: Bool = false
+    @ObservedObject var coinManager = CoinManager.shared
+    
+    private let baseUrl = "https://api.openai.com/v1/chat/completions"
+    private let firebaseManager = FirebaseManager()
+    private var chatGptKey: String?
+    // 키 오류를 대비해서 랜덤하게 키를 게속 바꿔줍니다.
+    
+    func getRandomKey(completion: @escaping () -> Void) {
+        let chatGptAPIKey = firebaseManager.getDoucument(apiName: "chatgptAPI") { [weak self] (key) in
+            self?.chatGptKey = key
+            completion()
+        }
+    }
+    
+    func sendMessage(messages: [Message]) -> AnyPublisher<chatGptResponse, Error> {
+        return Future <chatGptResponse, Error> { promise in
+            self.getRandomKey() {
+                let openAIMessages = messages.map({chatGptMessage(role: .user, content: $0.content)})
+                let body = chatGptBody(model: "gpt-4-vision-preview", messages: openAIMessages)
+                let headers: HTTPHeaders =  [
+                    "Authorization" : "Bearer \(self.chatGptKey ?? "키 값 오류")"
+                ]
+                
+                AF.request(self.baseUrl, method: .post, parameters: body, encoder: .json, headers: headers)
+                    .responseDecodable(of: chatGptResponse.self) { response in
+                        switch response.result {
+                        case .success(let result):
+                            print("success: \(result)")
+                        if !self.isCanceled {
+                            print("success: \(result)")
+                            promise(.success(result))
+                        }
+                        else{
+                            print("생성이 취소되었습니다.")
+                            self.coinManager.coinCaptionUse()
+                            self.isCanceled = false
+                        }
+                        case .failure(let error):
+                            print("error 상세 내용: \(error)")
+                            print("error_code: \(error._code)")
+                            promise(.failure(error))
+                        }
+                    }
+            }
+        }
+        .eraseToAnyPublisher()
+    }
+}

--- a/PostKit/PostKit/ViewModel/GptVisionService.swift
+++ b/PostKit/PostKit/ViewModel/GptVisionService.swift
@@ -1,0 +1,8 @@
+//
+//  GptVisionService.swift
+//  PostKit
+//
+//  Created by 김다빈 on 2/7/24.
+//
+
+import Foundation

--- a/PostKit/PostKit/ViewModel/GptVisionService.swift
+++ b/PostKit/PostKit/ViewModel/GptVisionService.swift
@@ -19,8 +19,8 @@ class GptVisionService: ObservableObject {
     private let baseUrl = "https://api.openai.com/v1/chat/completions"
     private let firebaseManager = FirebaseManager()
     private var chatGptKey: String?
-    // 키 오류를 대비해서 랜덤하게 키를 게속 바꿔줍니다.
     
+    // 키 오류를 대비해서 랜덤하게 키를 게속 바꿔줍니다.
     func getRandomKey(completion: @escaping () -> Void) {
         let chatGptAPIKey = firebaseManager.getDoucument(apiName: "chatgptAPI") { [weak self] (key) in
             self?.chatGptKey = key
@@ -28,32 +28,27 @@ class GptVisionService: ObservableObject {
         }
     }
     
-    func sendMessage(messages: [Message]) -> AnyPublisher<chatGptResponse, Error> {
-        return Future <chatGptResponse, Error> { promise in
+    func sendMessage(messages: [GptVisionMessage]) -> AnyPublisher<ChatGptVisionResponse, Error> {
+        return Future<ChatGptVisionResponse, Error> { promise in
             self.getRandomKey() {
-                let openAIMessages = messages.map({chatGptMessage(role: .user, content: $0.content)})
-                let body = chatGptBody(model: "gpt-4-vision-preview", messages: openAIMessages)
-                let headers: HTTPHeaders =  [
-                    "Authorization" : "Bearer \(self.chatGptKey ?? "키 값 오류")"
+                let body = ChatGptVisionBody(model: "gpt-4-vision-preview", messages: messages)
+                let headers: HTTPHeaders = [
+                    "Authorization": "Bearer \(self.chatGptKey ?? "키 값 오류")"
                 ]
                 
-                AF.request(self.baseUrl, method: .post, parameters: body, encoder: .json, headers: headers)
-                    .responseDecodable(of: chatGptResponse.self) { response in
+                AF.request(self.baseUrl, method: .post, parameters: body, encoder: JSONParameterEncoder.default, headers: headers)
+                    .responseDecodable(of: ChatGptVisionResponse.self) { response in
+                        debugPrint(response)
                         switch response.result {
                         case .success(let result):
-                            print("success: \(result)")
-                        if !self.isCanceled {
-                            print("success: \(result)")
-                            promise(.success(result))
-                        }
-                        else{
-                            print("생성이 취소되었습니다.")
-                            self.coinManager.coinCaptionUse()
-                            self.isCanceled = false
-                        }
+                            if !self.isCanceled {
+                                promise(.success(result))
+                            } else {
+                                print("생성이 취소되었습니다.")
+                                self.coinManager.coinCaptionUse()
+                                self.isCanceled = false
+                            }
                         case .failure(let error):
-                            print("error 상세 내용: \(error)")
-                            print("error_code: \(error._code)")
                             promise(.failure(error))
                         }
                     }

--- a/PostKit/PostKit/ViewModel/GptVisionService.swift
+++ b/PostKit/PostKit/ViewModel/GptVisionService.swift
@@ -33,6 +33,7 @@ class GptVisionService: ObservableObject {
     func sendMessage(messages: [GptVisionMessage]) -> AnyPublisher<ChatGptVisionResponse, Error> {
         return Future<ChatGptVisionResponse, Error> { promise in
             self.getRandomKey() {
+                let minToken = 300
                 let body = ChatGptVisionBody(model: "gpt-4-vision-preview", messages: messages)
                 let headers: HTTPHeaders = [
                     "Authorization": "Bearer \(self.chatGptKey ?? "키 값 오류")"

--- a/PostKit/PostKit/ViewModel/GptVisionService.swift
+++ b/PostKit/PostKit/ViewModel/GptVisionService.swift
@@ -15,10 +15,12 @@ class GptVisionService: ObservableObject {
     
     @AppStorage("_isCanceled") var isCanceled: Bool = false
     @ObservedObject var coinManager = CoinManager.shared
+    @ObservedObject var viewModel = ChatGptViewModel.shared
     
     private let baseUrl = "https://api.openai.com/v1/chat/completions"
     private let firebaseManager = FirebaseManager()
     private var chatGptKey: String?
+    
     
     // 키 오류를 대비해서 랜덤하게 키를 게속 바꿔줍니다.
     func getRandomKey(completion: @escaping () -> Void) {
@@ -35,6 +37,7 @@ class GptVisionService: ObservableObject {
                 let headers: HTTPHeaders = [
                     "Authorization": "Bearer \(self.chatGptKey ?? "키 값 오류")"
                 ]
+
                 
                 AF.request(self.baseUrl, method: .post, parameters: body, encoder: JSONParameterEncoder.default, headers: headers)
                     .responseDecodable(of: ChatGptVisionResponse.self) { response in


### PR DESCRIPTION
## 📌 관련 이슈
closed #287 

## Task TODOLIST
- [x] gpt 이미지 검색기능 추가
- [x] vision api 모델 추가
- [x] viewmodel 추가

## ✨ 개발 내용
<!-- 개발에 대한 내용을 적어주세요 -->
```
```
##  TroubleShotting
input으로 들어가는 content는 배열이여야 하고 다시 답변을 받는 content는 문자열이기 때문에 고민을 했었습니다. 하지만 둘다 받을 수 있는 방법을 찾아서 해결했습니다.
이미지가 token양이 너무 커서 답변으로 할당되는 token의 수가 너무적어 답변이 제대로 출력되지 않는 이슈가 있어서 이미지 해상도나 품질을 줄이는 방법과 프롬프트를 더욱더 정교하고 간단하게 해야할 것 같습니다.
```swift

import Foundation


struct ChatGptVisionBody: Encodable {
    let model: String
    let messages: [GptVisionMessage]
}

struct GptVisionMessage: Codable {
    let role: SenderRole
    let content: Contents
}

enum Contents: Codable {
    case string(String)
    case array([GptVisionContent])

    init(from decoder: Decoder) throws {
        let container = try decoder.singleValueContainer()
        if let array = try? container.decode([GptVisionContent].self) {
            self = .array(array)
        } else if let string = try? container.decode(String.self) {
            self = .string(string)
        } else {
            throw DecodingError.dataCorruptedError(in: container, debugDescription: "content data is not")
        }
    }

    func encode(to encoder: Encoder) throws {
        var container = encoder.singleValueContainer()
        switch self {
        case .string(let string):
            try container.encode(string)
        case .array(let array):
            try container.encode(array)
        }
    }
}


struct GptVisionContent: Codable {
    let type: String
    let text: String?
    let image_url: ImageURL?
}

struct ImageURL: Codable {
    let url: String
}

struct ChatGptVisionResponse: Decodable {
    let choices: [ChatGptVisionChoice]
}

struct ChatGptVisionChoice: Decodable {
    let finish_reason: String
    let message: GptVisionMessage
}

```

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
ios 자료가 너무 없어서 슬펐어요
